### PR TITLE
Update version of jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <version.dc-model>2.0.0-SNAPSHOT</version.dc-model>
     <version.geoip>2.8.0</version.geoip>
     <version.hamcrest-core>1.3</version.hamcrest-core>
-    <version.jackson>2.9.4</version.jackson>
+    <version.jackson>2.9.7</version.jackson>
     <version.jjwt>0.7.0</version.jjwt>
     <version.joda-time>2.9.4</version.joda-time>
     <version.junit>4.12</version.junit>


### PR DESCRIPTION
This PR updates the version of `jackson` dependency and fixes CVE-2018-7489.