### PR TITLE
Fileresource: `write` returns written bytes

### DIFF
--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/FileResourceRepository.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/FileResourceRepository.java
@@ -45,9 +45,9 @@ public interface FileResourceRepository<R extends FileResource> {
 
   Reader getReader(R resource) throws ResourceIOException;
 
-  void write(FileResource resource, String input) throws ResourceIOException;
+  long write(FileResource resource, String input) throws ResourceIOException;
 
-  void write(FileResource resource, InputStream inputStream) throws ResourceIOException;
+  long write(FileResource resource, InputStream inputStream) throws ResourceIOException;
 
   Set<String> findKeys(String keyPattern, FileResourcePersistenceType resourcePersistenceType) throws ResourceIOException;
 }

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/FileResourceRepositoryImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/FileResourceRepositoryImpl.java
@@ -250,7 +250,7 @@ public class FileResourceRepositoryImpl implements FileResourceRepository<FileRe
 
 
   @Override
-  public void write(FileResource resource, InputStream payload) throws ResourceIOException {
+  public long write(FileResource resource, InputStream payload) throws ResourceIOException {
 
     Assert.notNull(payload, "payload must not be null");
     Assert.notNull(resource, "payload must not be null");
@@ -270,7 +270,7 @@ public class FileResourceRepositoryImpl implements FileResourceRepository<FileRe
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Writing: " + uri);
       }
-      IOUtils.copy(payload, new FileOutputStream(Paths.get(uri).toFile()));
+      return IOUtils.copyLarge(payload, new FileOutputStream(Paths.get(uri).toFile()));
     } catch (IOException e) {
       String msg = "Could not write data to uri " + String.valueOf(uri);
       LOGGER.error(msg, e);
@@ -279,9 +279,9 @@ public class FileResourceRepositoryImpl implements FileResourceRepository<FileRe
   }
 
   @Override
-  public void write(FileResource resource, String input) throws ResourceIOException {
+  public long write(FileResource resource, String input) throws ResourceIOException {
     try (InputStream in = new ReaderInputStream(new StringReader(input), Charset.forName("UTF-8"))) {
-      write(resource, in);
+      return write(resource, in);
     } catch (IOException ex) {
       String msg = "Could not write data to uri " + String.valueOf(resource.getUri());
       LOGGER.error(msg, ex);

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/api/FileResourceService.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/api/FileResourceService.java
@@ -54,9 +54,9 @@ public interface FileResourceService {
 
   InputStream getInputStream(URI resourceUri) throws ResourceIOException;
 
-  void write(FileResource fileResource, String input) throws ResourceIOException;
+  long write(FileResource fileResource, String input) throws ResourceIOException;
 
-  void write(FileResource fileResource, InputStream inputStream) throws ResourceIOException;
+  long write(FileResource fileResource, InputStream inputStream) throws ResourceIOException;
 
   Set<String> findKeys(String keyPattern, FileResourcePersistenceType fileResourcePersistenceType) throws ResourceIOException;
 }

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/impl/service/FileResourceServiceImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/impl/service/FileResourceServiceImpl.java
@@ -50,13 +50,13 @@ public class FileResourceServiceImpl implements FileResourceService {
   }
 
   @Override
-  public void write(FileResource fileResource, String input) throws ResourceIOException {
-    fileResourceRepository.write(fileResource, input);
+  public long write(FileResource fileResource, String input) throws ResourceIOException {
+    return fileResourceRepository.write(fileResource, input);
   }
 
   @Override
-  public void write(FileResource fileResource, InputStream inputStream) throws ResourceIOException {
-    fileResourceRepository.write(fileResource, inputStream);
+  public long write(FileResource fileResource, InputStream inputStream) throws ResourceIOException {
+    return fileResourceRepository.write(fileResource, inputStream);
   }
 
   @Override


### PR DESCRIPTION
With this PR the `write()` function (`FileResource`) now returns the number of written bytes (instead of `void`).