### PR TITLE
Travis CI: OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
 - openjdk8
 - oraclejdk8
+- openjdk11
 addons:
   apt:
     packages:

--- a/dc-commons-prosemirror/dc-commons-prosemirror-model-jackson/pom.xml
+++ b/dc-commons-prosemirror/dc-commons-prosemirror-model-jackson/pom.xml
@@ -1,21 +1,25 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>de.digitalcollections.commons</groupId>
     <artifactId>dc-commons-prosemirror</artifactId>
     <version>2.0.0-SNAPSHOT</version>
   </parent>
-  
+
   <name>DigitalCollections: Commons ProseMirror Model Jackson</name>
   <artifactId>dc-commons-prosemirror-model-jackson</artifactId>
   <packaging>jar</packaging>
-  
+
   <dependencies>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -24,11 +28,16 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>2.9.7</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.digitalcollections.commons</groupId>
+      <artifactId>dc-commons-prosemirror-model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -40,8 +49,29 @@
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>de.digitalcollections.commons</groupId>
-      <artifactId>dc-commons-prosemirror-model</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-surefire-provider</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/dc-commons-prosemirror/pom.xml
+++ b/dc-commons-prosemirror/pom.xml
@@ -51,6 +51,30 @@
         <version>${version.junit5}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${version.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${version.junit5-platform}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>${version.junit5-platform}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-surefire-provider</artifactId>
+        <version>${version.junit5-platform}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   

--- a/dc-commons-springboot/src/main/java/de/digitalcollections/commons/springboot/metrics/MetricsService.java
+++ b/dc-commons-springboot/src/main/java/de/digitalcollections/commons/springboot/metrics/MetricsService.java
@@ -26,7 +26,7 @@ public class MetricsService {
 
   /**
    * Sets the value of a gauge
-   * @param name Name of the gauge, postfixed with <tt>.amount</tt>
+   * @param name Name of the gauge, postfixed with <code>.amount</code>
    * @param value Value of the gauge
    */
   public void setGauge(String name, long value) {
@@ -35,8 +35,8 @@ public class MetricsService {
 
   /**
    * Sets the value of a gauge
-   * @param name Name of the gauge, postfixed with <tt>.amount</tt>
-   * @param tag Name of the tag (key is <tt>type</tt>)
+   * @param name Name of the gauge, postfixed with <code>.amount</code>
+   * @param tag Name of the tag (key is <code>type</code>)
    * @param value Value of the gauge
    */
   public void setGauge(String name, String tag, long value) {
@@ -46,7 +46,7 @@ public class MetricsService {
 
   /**
    * Sets the value of a gauge
-   * @param name Name of the gauge, postfixed with <tt>.amount</tt>
+   * @param name Name of the gauge, postfixed with <code>.amount</code>
    * @param tagKey Name of the tag
    * @param tagValue Value of the tag
    * @param value Value of the gauge
@@ -57,7 +57,7 @@ public class MetricsService {
 
   /**
    * Increases the gauge counter by one
-   * @param name Name of the gauge, postfixed with <tt>.amount</tt>
+   * @param name Name of the gauge, postfixed with <code>.amount</code>
    * @param tag Name of the tag
    */
   public void increaseCounter(String name, String tag) {
@@ -66,7 +66,7 @@ public class MetricsService {
 
   /**
    * Increases the gauge counter with a custom increment
-   * @param name Name of the gauge, postfixed with <tt>.amount</tt>
+   * @param name Name of the gauge, postfixed with <code>.amount</code>
    * @param tag Name of the tag
    * @param increment Increment value
    */
@@ -76,7 +76,7 @@ public class MetricsService {
 
   /**
    * Increases the gauge counter and logs its accompanied duration
-   * @param name Name of the gauge, postfixed with <tt>.amount</tt> and name of the timer, postfixed with <tt>.duration</tt>
+   * @param name Name of the gauge, postfixed with <code>.amount</code> and name of the timer, postfixed with <code>.duration</code>
    * @param tag Name of the tag
    * @param durationMillis Duration in milliseconds
    */
@@ -86,7 +86,7 @@ public class MetricsService {
 
   /**
    * Increases the gauge counter and logs its accompanied duration including percentiles (0.5 and 0.95) and histogram
-   * @param name Name of the gauge, postfixed with <tt>.amount</tt> and name of the timer, postfixed with <tt>.duration</tt>
+   * @param name Name of the gauge, postfixed with <code>.amount</code> and name of the timer, postfixed with <code>.duration</code>
    * @param tag Name of the tag (must not be null)
    * @param durationMillis Duration in milliseconds
    */

--- a/dc-commons-springsecurity/pom.xml
+++ b/dc-commons-springsecurity/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
@@ -29,6 +29,10 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -91,18 +95,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>
@@ -115,6 +107,18 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test-autoconfigure</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/dc-commons-springsecurity/pom.xml
+++ b/dc-commons-springsecurity/pom.xml
@@ -23,6 +23,10 @@
       <artifactId>jjwt</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <version.geoip>2.8.0</version.geoip>
     <version.hamcrest-core>1.3</version.hamcrest-core>
     <version.jackson>2.9.7</version.jackson>
+    <version.jaxb-api>2.2.11</version.jaxb-api>
     <version.javax.annotation-api>1.2</version.javax.annotation-api>
     <version.jjwt>0.7.0</version.jjwt>
     <version.joda-time>2.9.4</version.joda-time>
@@ -50,8 +51,8 @@
     <version.junit5>5.1.0</version.junit5>
     <version.junit5-platform>1.1.0</version.junit5-platform>
     <version.logback-classic>1.2.3</version.logback-classic>
-    <version.mockito-java8>2.0.1</version.mockito-java8>
-    <version.mockito-core>2.7.6</version.mockito-core>
+    <version.mockito-java8>2.5.0</version.mockito-java8>
+    <version.mockito-core>2.23.0</version.mockito-core>
     <version.saxon>9.8.0-6</version.saxon>
     <version.servlet-api>3.1.0</version.servlet-api>
     <version.slf4j>1.7.22</version.slf4j>
@@ -60,14 +61,15 @@
     <version.spring-boot>2.0.5.RELEASE</version.spring-boot>
     <version.spring-boot-starter-jsondoc>1.2.19</version.spring-boot-starter-jsondoc>
     <version.spring-data-commons>1.13.4.RELEASE</version.spring-data-commons>
-    <version.spring-security>5.0.8.RELEASE</version.spring-security>
+    <version.spring-security>5.1.1.RELEASE</version.spring-security>
     <version.thymeleaf>3.0.9.RELEASE</version.thymeleaf>
 
     <!-- Plugin versions -->
     <version.jacoco-maven-plugin>0.8.2</version.jacoco-maven-plugin>
-    <version.maven-compiler-plugin>3.1</version.maven-compiler-plugin>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-javadoc-plugin>3.0.1</version.maven-javadoc-plugin>
+    <version.maven-junit-jupiter-engine-plugin>3.0.1</version.maven-junit-jupiter-engine-plugin>
     <version.nexus-staging-maven-plugin>1.6.7</version.nexus-staging-maven-plugin>
     <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
     <version.maven-surefire-plugin>2.22.1</version.maven-surefire-plugin>
@@ -128,6 +130,11 @@
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${version.servlet-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${version.jaxb-api}</version>
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>
@@ -377,14 +384,10 @@
           <properties>
             <excludeTags>integration-test</excludeTags>
           </properties>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
         </configuration>
         <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${version.junit5-platform}</version>
-            <scope>runtime</scope>
-          </dependency>
           <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -401,8 +401,6 @@
           <properties>
             <excludeTags>integration-test</excludeTags>
           </properties>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
         </configuration>
         <dependencies>
           <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <version.geoip>2.8.0</version.geoip>
     <version.hamcrest-core>1.3</version.hamcrest-core>
     <version.jackson>2.9.7</version.jackson>
+    <version.javax.annotation-api>1.2</version.javax.annotation-api>
     <version.jjwt>0.7.0</version.jjwt>
     <version.joda-time>2.9.4</version.joda-time>
     <version.junit>4.12</version.junit>
@@ -63,13 +64,13 @@
     <version.thymeleaf>3.0.9.RELEASE</version.thymeleaf>
 
     <!-- Plugin versions -->
-    <version.jacoco-maven-plugin>0.7.9</version.jacoco-maven-plugin>
+    <version.jacoco-maven-plugin>0.8.2</version.jacoco-maven-plugin>
     <version.maven-compiler-plugin>3.1</version.maven-compiler-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
-    <version.maven-javadoc-plugin>2.10.4</version.maven-javadoc-plugin>
+    <version.maven-javadoc-plugin>3.0.1</version.maven-javadoc-plugin>
     <version.nexus-staging-maven-plugin>1.6.7</version.nexus-staging-maven-plugin>
     <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
-    <version.maven-surefire-plugin>2.19.1</version.maven-surefire-plugin>
+    <version.maven-surefire-plugin>2.22.1</version.maven-surefire-plugin>
     <version.versions-maven-plugin>2.3</version.versions-maven-plugin>
   </properties>
 
@@ -116,6 +117,12 @@
         <groupId>io.jsonwebtoken</groupId>
         <artifactId>jjwt</artifactId>
         <version>${version.jjwt}</version>
+      </dependency>
+      <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${version.javax.annotation-api}</version>
       </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <version.logback-classic>1.2.3</version.logback-classic>
     <version.mockito-java8>2.5.0</version.mockito-java8>
     <version.mockito-core>2.23.0</version.mockito-core>
+    <version.openfeign>10.1.0</version.openfeign>
     <version.saxon>9.8.0-6</version.saxon>
     <version.servlet-api>3.1.0</version.servlet-api>
     <version.slf4j>1.7.22</version.slf4j>


### PR DESCRIPTION
This PR adds openjdk11 to Travis CI build matrix and introduces various fixes for openjdk11 :tada:

It also fixes code coverage calculation with `jacoco`.