### PR TITLE
Security alert: update version of jackson

### DIFF
--- a/dc-commons-prosemirror/dc-commons-prosemirror-model-jackson/pom.xml
+++ b/dc-commons-prosemirror/dc-commons-prosemirror-model-jackson/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/dc-commons-prosemirror/dc-commons-prosemirror-model-jackson/pom.xml
+++ b/dc-commons-prosemirror/dc-commons-prosemirror-model-jackson/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.7</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <version.dc-model>2.1.0</version.dc-model>
     <version.geoip>2.8.0</version.geoip>
     <version.hamcrest-core>1.3</version.hamcrest-core>
-    <version.jackson>2.9.7</version.jackson>
+    <version.jackson>2.9.8</version.jackson>
     <version.jaxb-api>2.2.11</version.jaxb-api>
     <version.javax.annotation-api>1.2</version.javax.annotation-api>
     <version.jdbi3>3.0.1</version.jdbi3>


### PR DESCRIPTION
This PR updates the version of `jackson` to fix CVE-2018-19360, CVE-2018-19362 and CVE-2018-19361.

This was found during a GitHub Security Scan.