### PR TITLE
Refactor code to use constructor injection

### DIFF
--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/impl/service/FileResourceServiceImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/impl/service/FileResourceServiceImpl.java
@@ -17,8 +17,12 @@ import org.w3c.dom.Document;
 @Service
 public class FileResourceServiceImpl implements FileResourceService {
 
+  private final FileResourceRepository fileResourceRepository;
+
   @Autowired
-  private FileResourceRepository fileResourceRepository;
+  public FileResourceServiceImpl(FileResourceRepository fileResourceRepository) {
+    this.fileResourceRepository = fileResourceRepository;
+  }
 
   @Override
   public FileResource create(String key, FileResourcePersistenceType fileResourcePersistenceType, MimeType mimeType) throws ResourceIOException {

--- a/dc-commons-file/src/test/java/de/digitalcollections/commons/file/backend/impl/resolver/MultiPatternsFileNameResolverImplTest.java
+++ b/dc-commons-file/src/test/java/de/digitalcollections/commons/file/backend/impl/resolver/MultiPatternsFileNameResolverImplTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
@@ -74,8 +76,9 @@ public class MultiPatternsFileNameResolverImplTest {
   static class SpringConfigBackendFileTest extends SpringConfigCommonsFile {
 
     @Bean
-    public FileNameResolver fileNameResolver() {
-      return new MultiPatternsFileNameResolverImpl();
+    public FileNameResolver fileNameResolver(@Value(value = "${multiPatternResolvingFile:}") String multiPatternResolvingFile,
+                                             ResourceLoader resourceLoader) {
+      return new MultiPatternsFileNameResolverImpl(multiPatternResolvingFile, resourceLoader);
     }
   }
 }


### PR DESCRIPTION
Dependency injection via attributes is discouraged because it makes testing more complicated and often produces an overall higher complexity.