### PR TITLE
xml: Add universal namespace resolver to simplify working with namespaced XML

### DIFF
--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/UniversalNamespaceContext.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/UniversalNamespaceContext.java
@@ -1,0 +1,51 @@
+package de.digitalcollections.commons.xml.xpath;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
+import org.w3c.dom.Document;
+
+/**
+ * Namespace context that uses the document's declared namespaces, in addition to user-defined prefixes.
+ */
+public class UniversalNamespaceContext implements NamespaceContext {
+  private final Document doc;
+  private HashMap<String, String> customPrefixes;
+
+  public UniversalNamespaceContext(Document doc) {
+    this.doc = doc;
+  }
+
+  /** Add a user-defined namespace. Takes precedence over the document's declared namespaces. */
+  public void addNamespace(String prefix, String uri) {
+    this.customPrefixes.put(prefix, uri);
+  }
+
+  @Override
+  public String getNamespaceURI(String prefix) {
+    if (prefix.equals(XMLConstants.DEFAULT_NS_PREFIX)) {
+      return doc.lookupNamespaceURI(null);
+    }
+    String uri = customPrefixes.get(prefix);
+    if (uri == null) {
+      uri = doc.lookupNamespaceURI(prefix);
+    }
+    return uri;
+  }
+
+  @Override
+  public String getPrefix(String namespaceURI) {
+    return customPrefixes.entrySet().stream()
+        .filter(e -> e.getValue().equals(namespaceURI))
+        .map(Entry::getKey)
+        .findFirst()
+        .orElseGet(() -> doc.lookupPrefix(namespaceURI));
+  }
+
+  @Override
+  public Iterator<String> getPrefixes(String namespaceURI) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathExpressionCache.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathExpressionCache.java
@@ -4,6 +4,7 @@ import de.digitalcollections.commons.xml.namespaces.DigitalCollectionsNamespaceC
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
@@ -17,9 +18,14 @@ public class XPathExpressionCache {
   private final XPath xpath;
 
   public XPathExpressionCache() {
+    this(new DigitalCollectionsNamespaceContext());
+  }
+
+  public XPathExpressionCache(NamespaceContext namespaceCtx) {
     cache = new ConcurrentHashMap<>();
     xpath = xPathFactory.newXPath();
-    xpath.setNamespaceContext(new DigitalCollectionsNamespaceContext());
+    xpath.setNamespaceContext(namespaceCtx);
+
   }
 
   public XPathExpression get(String expression) {

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
@@ -1,10 +1,12 @@
 package de.digitalcollections.commons.xml.xpath;
 
+import de.digitalcollections.commons.xml.namespaces.DigitalCollectionsNamespaceContext;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.namespace.QName;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -28,22 +30,21 @@ import org.w3c.dom.NodeList;
  * Provides a lightweight wrapper around the Document class to make XPath queries less painful and verbose.
  */
 public class XPathWrapper {
-  private static XPathExpressionCache GLOBAL_CACHE = new XPathExpressionCache();
-
   private static final Logger LOGGER = LoggerFactory.getLogger(XPathWrapper.class);
   private Document document;
   private XPathExpressionCache expressionCache;
 
-  private XPathWrapper() {
+  public XPathWrapper(Document document) {
+    this(document, new DigitalCollectionsNamespaceContext());
+  }
+
+  public XPathWrapper(Document document, NamespaceContext namespaceCtx) {
+    this(document, new XPathExpressionCache(namespaceCtx));
   }
 
   public XPathWrapper(Document document, XPathExpressionCache expressionCache) {
     this.document = document;
     this.expressionCache = expressionCache;
-  }
-
-  public XPathWrapper(Document document) {
-    this(document, GLOBAL_CACHE);
   }
 
   public void setDefaultNamespace(String namespaceUrl) {

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
@@ -30,12 +30,13 @@ import org.w3c.dom.NodeList;
  * Provides a lightweight wrapper around the Document class to make XPath queries less painful and verbose.
  */
 public class XPathWrapper {
+  private static XPathExpressionCache GLOBAL_CACHE = new XPathExpressionCache(new DigitalCollectionsNamespaceContext());
   private static final Logger LOGGER = LoggerFactory.getLogger(XPathWrapper.class);
   private Document document;
   private XPathExpressionCache expressionCache;
 
   public XPathWrapper(Document document) {
-    this(document, new DigitalCollectionsNamespaceContext());
+    this(document, GLOBAL_CACHE);
   }
 
   public XPathWrapper(Document document, NamespaceContext namespaceCtx) {


### PR DESCRIPTION
The `DigitalCollectionsNamespaceContext` remains the default, but you can now opt to use a custom `NamespaceContext` instance.

Included is a `UniversalNamespaceContext` that allows setting user-defined `(prefix, uri)` mappings, but falls back to the namespace prefixes declared in the document's root element.