### PR TITLE
Bump dependencies to their latest version

### DIFF
--- a/dc-commons-springmvc/pom.xml
+++ b/dc-commons-springmvc/pom.xml
@@ -15,14 +15,14 @@
 
   <properties>
     <version.assertj>3.13.2</version.assertj>
-    <version.guava>28.0-jre</version.guava>
-    <version.junit>5.5.1</version.junit>
-    <version.mockito-core>3.0.0</version.mockito-core>
+    <version.guava>28.1-jre</version.guava>
+    <version.junit>5.5.2</version.junit>
+    <version.mockito-core>3.1.0</version.mockito-core>
     <version.mockito-java8>2.5.0</version.mockito-java8>
     <version.servlet-api>4.0.1</version.servlet-api>
-    <version.slf4j>1.7.26</version.slf4j>
-    <version.spring>5.1.8.RELEASE</version.spring>
-    <version.spring-security>5.1.5.RELEASE</version.spring-security>
+    <version.slf4j>1.7.28</version.slf4j>
+    <version.spring>5.2.0.RELEASE</version.spring>
+    <version.spring-security>5.2.0.RELEASE</version.spring-security>
     <version.thymeleaf>3.0.11.RELEASE</version.thymeleaf>
   </properties>
 


### PR DESCRIPTION
This PR upgrades some libraries in the submodule `dc-commons-springmvc` to their latest version.