### PR TITLE
tree-wide pom: remove hamcrest-core

### DIFF
--- a/dc-commons-server/pom.xml
+++ b/dc-commons-server/pom.xml
@@ -16,7 +16,6 @@
   <properties>
     <version.assertj>3.14.0</version.assertj>
     <version.geoip>2.13.0</version.geoip>
-    <version.hamcrest-core>2.2</version.hamcrest-core>
     <version.jackson-databind>2.10.1</version.jackson-databind>
     <version.junit>5.5.2</version.junit>
     <version.servlet-api>4.0.1</version.servlet-api>
@@ -49,12 +48,6 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${version.assertj}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${version.hamcrest-core}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dc-commons-springboot/pom.xml
+++ b/dc-commons-springboot/pom.xml
@@ -17,7 +17,6 @@
   <properties>
     <version.assertj>3.14.0</version.assertj>
     <version.dc-commons-springsecurity>4.1.0-SNAPSHOT</version.dc-commons-springsecurity>
-    <version.hamcrest-core>2.2</version.hamcrest-core>
     <version.jackson-annotations>2.10.1</version.jackson-annotations>
     <version.jackson-databind>2.10.1</version.jackson-databind>
     <version.junit>5.5.2</version.junit>
@@ -61,12 +60,6 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${version.assertj}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${version.hamcrest-core}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dc-commons-springsecurity/pom.xml
+++ b/dc-commons-springsecurity/pom.xml
@@ -16,7 +16,6 @@
   
   <properties>
     <version.assertj>3.14.0</version.assertj>
-    <version.hamcrest-core>2.2</version.hamcrest-core>
     <version.jackson>2.10.1</version.jackson>
     <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
     <version.javax.servlet-api>4.0.1</version.javax.servlet-api>
@@ -61,12 +60,6 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>${version.assertj}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${version.hamcrest-core}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hi,

this PR removes `hamcrest-core` as (test) dependency for maintainability reasons, as it is not needed.