### PR TITLE
Introducing findOrCreate to get access to the underlying filenames of…

### DIFF
--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/api/FileResourceService.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/api/FileResourceService.java
@@ -105,6 +105,14 @@ public interface FileResourceService {
   }
 
   /**
+   * @param identifier identifier of FileResource, used to lookup URI for FileResource
+   * @param mimeType mimetype of the FileResource
+   * @return FileResource implementation matching mimetype and URI resolved using identifier. If the file resource does not exist, create it
+   * @throws ResourceIOException thrown if no URI can be resolved for FileResource with given mimetype and identifier
+   */
+  FileResource findOrCreate(String identifier, MimeType mimeType) throws ResourceIOException;
+
+  /**
    * Convenience method for directly getting FileResource binary data as byte[].
    * @param resource FileResource containing URI for accessing FileResource data
    * @return binary data of FileResource as byte[]

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/impl/FileResourceServiceImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/business/impl/FileResourceServiceImpl.java
@@ -56,6 +56,16 @@ public class FileResourceServiceImpl implements FileResourceService {
   }
 
   @Override
+  public FileResource findOrCreate(String identifier, MimeType mimeType) throws ResourceIOException {
+    try {
+      return find(identifier, mimeType);
+      // find() returns a ResourceIOException, if a resource does not exist!
+    } catch (ResourceIOException | ResourceNotFoundException e) {
+      return repository.create(identifier, mimeType);
+    }
+  }
+
+  @Override
   public byte[] getAsBytes(FileResource resource) throws ResourceIOException, ResourceNotFoundException {
     try {
       return IOUtils.toByteArray(getInputStream(resource));


### PR DESCRIPTION
… a not yet existing resource