### PR TITLE
Extend xpathmapper to be able to work without templates

### DIFF
--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -11,5 +11,6 @@ public @interface XPathBinding {
   String valueTemplate() default "";
   String defaultNamespace() default "";
   boolean multiLanguage() default false;
-  XPathVariable[] variables();
+  XPathVariable[] variables() default {};
+  String[] expressions() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -269,6 +270,8 @@ public class XPathMapper implements InvocationHandler {
    * @return true, when the set is empty or contains just a single empty string
    */
   private boolean isEmptyOrBlankStringSet(Set<String> set) {
-    return set.isEmpty() || ((set.size() == 1) && set.iterator().next().length() < 1);
+    return set.stream()
+        .filter(Objects::nonNull)
+        .allMatch(String::isEmpty);
   }
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -63,15 +63,6 @@ public class XPathMapper implements InvocationHandler {
     // Set of expressions from the expression string for direct evaluation w/o templates
     Set<String> expressions = new HashSet<>(Arrays.asList(binding.expressions()));
 
-    // If both, variables and expressions are set, we must throw an exception, because
-    // they are mutually exclusive
-    if (!isEmptyOrBlankStringSet(variables) && !binding.valueTemplate().isEmpty() && !isEmptyOrBlankStringSet(expressions)) {
-      throw new XPathMappingException("Only one XPath evaluation type, either variables or expressions, is allowed, not both at the same time!");
-    }
-    // If neither variables nor expressions are defined, we must throw an Exception, too
-    if (isEmptyOrBlankStringSet(variables) && binding.valueTemplate().isEmpty() && isEmptyOrBlankStringSet(expressions)) {
-      throw new XPathMappingException("Either variables or expressions must be used, not none of them!");
-    }
 
     // Sanity checks
     if (binding.multiLanguage()) {
@@ -83,6 +74,12 @@ public class XPathMapper implements InvocationHandler {
       if (!method.getReturnType().isAssignableFrom(String.class)) {
         throw new XPathMappingException("Return type must be String if multiLanguage=false;");
       }
+    }
+    if (!isEmptyOrBlankStringSet(variables) && !binding.valueTemplate().isEmpty() && !isEmptyOrBlankStringSet(expressions)) {
+      throw new XPathMappingException("Only one XPath evaluation type, either variables or expressions, is allowed, not both at the same time!");
+    }
+    if (isEmptyOrBlankStringSet(variables) && binding.valueTemplate().isEmpty() && isEmptyOrBlankStringSet(expressions)) {
+      throw new XPathMappingException("Either variables or expressions must be used, not none of them!");
     }
 
     // Set default namespace, if applicable

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -60,6 +60,19 @@ public class XPathMapper implements InvocationHandler {
     // Set of variable names from the template string
     Set<String> variables = getVariables(binding.valueTemplate());
 
+    // Set of expressions from the expression string for direct evaluation w/o templates
+    Set<String> expressions = new HashSet<>(Arrays.asList(binding.expressions()));
+
+    // If both, variables and expressions are set, we must throw an exception, because
+    // they are mutually exclusive
+    if (!isEmptyOrBlankStringSet(variables) && !binding.valueTemplate().isEmpty() && !isEmptyOrBlankStringSet(expressions)) {
+      throw new XPathMappingException("Only one XPath evaluation type, either variables or expressions, is allowed, not both at the same time!");
+    }
+    // If neither variables nor expressions are defined, we must throw an Exception, too
+    if (isEmptyOrBlankStringSet(variables) && binding.valueTemplate().isEmpty() && isEmptyOrBlankStringSet(expressions)) {
+      throw new XPathMappingException("Either variables or expressions must be used, not none of them!");
+    }
+
     // Sanity checks
     if (binding.multiLanguage()) {
       if (!method.getReturnType().isAssignableFrom(Map.class)) {
@@ -96,6 +109,7 @@ public class XPathMapper implements InvocationHandler {
       return null;
     }
   }
+
 
   private Map<Locale, String> executeTemplate(String templateString, Map<String, Map<Locale, String>> resolvedVariables) throws XPathExpressionException {
     Set<Locale> langs = resolvedVariables.values()
@@ -228,5 +242,13 @@ public class XPathMapper implements InvocationHandler {
       }
     }
     return result;
+  }
+
+  /**
+   * @param set A set with string elements
+   * @return true, when the set is empty or contains just a single empty string
+   */
+  private boolean isEmptyOrBlankStringSet(Set<String> set) {
+    return set.isEmpty() || ((set.size() == 1) && set.iterator().next().length() < 1);
   }
 }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -1,17 +1,19 @@
 package de.digitalcollections.commons.xml.xpath;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.InputStream;
 import java.util.Locale;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+@DisplayName("The XPath Mapper")
 public class XPathMapperTest {
 
   private TestMapper mapper;
@@ -45,6 +47,31 @@ public class XPathMapperTest {
 
     @XPathBinding(valueTemplate = "{broken}", variables = {})
     String broken() throws XPathMappingException;
+
+    @XPathBinding(
+        defaultNamespace = TEI_NS,
+        multiLanguage = true,
+        expressions = {
+            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+        }
+    )
+    Map<Locale, String> getAuthorFromExpression() throws XPathMappingException;
+
+    @XPathBinding(
+        defaultNamespace = TEI_NS,
+        valueTemplate = "{author}",
+        multiLanguage = true,
+        variables = {
+            @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"})
+        },
+        expressions = {
+            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+        }
+    )
+    Map<Locale, String> getAuthorFromExpressionAndVariables() throws XPathMappingException;
+
+    @XPathBinding()
+    String getNothing() throws XPathMappingException;
   }
 
   @BeforeEach
@@ -57,19 +84,41 @@ public class XPathMapperTest {
     this.mapper = XPathMapper.makeProxy(doc, TestMapper.class);
   }
 
+  @DisplayName("shall evaluate a template with a single variable")
   @Test
   public void testTemplateWithSingleVariable() throws Exception {
     assertThat(mapper.getAuthor().get(Locale.GERMAN)).isEqualTo("Kugelmann, Hans");
     assertThat(mapper.getAuthor().get(Locale.ENGLISH)).isEqualTo("Name, English");
   }
 
+  @DisplayName("shall evaluate a template with context")
   @Test
   public void testTemplateWithContext() throws Exception {
     assertThat(mapper.getTitle()).isEqualTo("Ein Titel: Ein Untertitel");
   }
 
+  @DisplayName("shall throw an exception, when a template variable is missing")
   @Test
   public void testMissingVariableThrows() throws Exception {
     assertThatThrownBy(mapper::broken).isInstanceOf(XPathMappingException.class).hasMessageContaining("Could not resolve variable");
+  }
+
+  @DisplayName("shall evaluate an expression without template")
+  @Test
+  public void testExpression() throws Exception {
+    assertThat(mapper.getAuthorFromExpression().get(Locale.GERMAN)).isEqualTo("Kugelmann, Hans");
+    assertThat(mapper.getAuthorFromExpression().get(Locale.ENGLISH)).isEqualTo("Name, English");
+  }
+
+  @DisplayName("shall throw an exception, when templates and expressions are used at the same time")
+  @Test
+  public void testTemplatesAndExpressionsThrowException() {
+    assertThatThrownBy(mapper::getAuthorFromExpressionAndVariables).isInstanceOf(XPathMappingException.class).hasMessageContaining("Only one XPath evaluation type");
+  }
+
+  @DisplayName("shall throw an exception, when neither templares nor expressions are defined")
+  @Test
+  public void testNoTemplatesAndExpressionsThrowException() {
+    assertThatThrownBy(mapper::getNothing).isInstanceOf(XPathMappingException.class).hasMessageContaining("Either variables or expressions must be used");
   }
 }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -52,7 +52,7 @@ public class XPathMapperTest {
         defaultNamespace = TEI_NS,
         multiLanguage = true,
         expressions = {
-            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+            BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"
         }
     )
     Map<Locale, String> getAuthorFromExpression() throws XPathMappingException;
@@ -65,7 +65,7 @@ public class XPathMapperTest {
             @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"})
         },
         expressions = {
-            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+            BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"
         }
     )
     Map<Locale, String> getAuthorFromExpressionAndVariables() throws XPathMappingException;


### PR DESCRIPTION
To be able to evaluate XPath expressions without using a template, the XPathBinding annotation was modifed to use a new field, `expressions`. Because of that, the field `variables` had to be made optional. It is guaranteed, that never both fields are used at the same time.

The XPathMapper is able to evaluate the new field `expressions` and return the results directly without a value template.