### PR TITLE
Ability to return multivalued fields in expressions

### DIFF
--- a/dc-commons-xml/pom.xml
+++ b/dc-commons-xml/pom.xml
@@ -15,12 +15,18 @@
   
   <properties>
     <version.assertj>3.15.0</version.assertj>
+    <version.guava>28.2-jre</version.guava>
     <version.junit>5.6.0</version.junit>
     <version.saxon>9.9.1-4</version.saxon>
     <version.slf4j>1.7.30</version.slf4j>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${version.guava}</version>
+    </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -11,5 +11,6 @@ public @interface XPathBinding {
   String valueTemplate() default "";
   String defaultNamespace() default "";
   boolean multiLanguage() default false;
-  XPathVariable[] variables();
+  XPathVariable[] variables() default {};
+  String[] expressions() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -13,8 +13,7 @@ public @interface XPathBinding {
 
   /**
    * @deprecated
-   * Specifying the return type is sufficient, this
-   * field will be removed in future.
+   * Specifying the return type is sufficient, this field will be removed in future.
    * @return flag for returning localized content
    */
   @Deprecated()

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -11,6 +11,7 @@ public @interface XPathBinding {
   String valueTemplate() default "";
   String defaultNamespace() default "";
   boolean multiLanguage() default false;
+  boolean multiValue() default false;
   XPathVariable[] variables() default {};
   String[] expressions() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -16,7 +16,7 @@ public @interface XPathBinding {
    * Specifying the return type is sufficient, this field will be removed in future.
    * @return flag for returning localized content
    */
-  @Deprecated()
+  @Deprecated
   boolean multiLanguage() default false;
 
   XPathVariable[] variables() default {};

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -13,8 +13,7 @@ public @interface XPathBinding {
 
   /**
    * @deprecated
-   * Specifying the return type is sufficient, this field will be removed in future.
-   * @return flag for returning localized content
+   * Specifying the return type is sufficient, this field will be removed in future and is simply ignored for now.
    */
   @Deprecated
   boolean multiLanguage() default false;

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -60,6 +60,19 @@ public class XPathMapper implements InvocationHandler {
     // Set of variable names from the template string
     Set<String> variables = getVariables(binding.valueTemplate());
 
+    // Set of expressions from the expression string for direct evaluation w/o templates
+    Set<String> expressions = new HashSet<>(Arrays.asList(binding.expressions()));
+
+    // If both, variables and expressions are set, we must throw an exception, because
+    // they are mutually exclusive
+    if (!isEmptyOrBlankStringSet(variables) && !binding.valueTemplate().isEmpty() && !isEmptyOrBlankStringSet(expressions)) {
+      throw new XPathMappingException("Only one XPath evaluation type, either variables or expressions, is allowed, not both at the same time!");
+    }
+    // If neither variables nor expressions are defined, we must throw an Exception, too
+    if (isEmptyOrBlankStringSet(variables) && binding.valueTemplate().isEmpty() && isEmptyOrBlankStringSet(expressions)) {
+      throw new XPathMappingException("Either variables or expressions must be used, not none of them!");
+    }
+
     // Sanity checks
     if (binding.multiLanguage()) {
       if (!method.getReturnType().isAssignableFrom(Map.class)) {
@@ -96,6 +109,7 @@ public class XPathMapper implements InvocationHandler {
       return null;
     }
   }
+
 
   private Map<Locale, String> executeTemplate(String templateString, Map<String, Map<Locale, String>> resolvedVariables) throws XPathExpressionException {
     Set<Locale> langs = resolvedVariables.values()
@@ -228,5 +242,13 @@ public class XPathMapper implements InvocationHandler {
       }
     }
     return result;
+  }
+
+  /**
+   * @param set A set with string elements
+   * @return true, when the set is empty or contains just a single empty string
+   */
+  private boolean isEmptyOrBlankStringSet(Set<String> set) {
+    return set.isEmpty() || ((set.size() == 1) && set.iterator().next().length() < 1);
   }
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -117,7 +117,7 @@ public class XPathMapper implements InvocationHandler {
       } else {
         Map<Locale, String> out = new HashMap<>();
         for (Entry<Locale, List<String>> resolvedVariable : resolved.entrySet()) {
-          // We use the first match only
+          // We only use the first match, since we want to return a single value
           out.put(resolvedVariable.getKey(), resolvedVariable.getValue().get(0));
         }
         return out;

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -105,7 +105,7 @@ public class XPathMapper implements InvocationHandler {
 
   private Object evaluateExpressions(Set<String> expressions, boolean multiValueReturnType, boolean multiLanguage)  {
     Map<Locale, List<String>> resolved = resolveVariables(expressions.toArray(new String[]{}), multiValueReturnType);
-    if (multiLanguage ) {
+    if (multiLanguage) {
       if (multiValueReturnType) {
         Map<Locale, List<String>> out = new HashMap<>();
         for (Entry<Locale, List<String>> resolvedVariable : resolved.entrySet()) {
@@ -310,11 +310,11 @@ public class XPathMapper implements InvocationHandler {
   }
 
   /**
-   * Verification of the return type:
+   * Verification of the return type.
    * <br/>
    * <ul>
    * <li>Multi language fields can return single and multi valued content, so the return types are
-   * <code>Map&lt;Locale,String&gt;</li> and <code>Map&lt;Locale,List&lt;String&gt;&gt;</code>, but
+   * <code>Map&lt;Locale,String&gt;</code> and <code>Map&lt;Locale,List&lt;String&gt;&gt;</code>, but
    * multi valued content is only allowed on expressions, not in template evaluations.
    * <li>For a single valued, non localized field, it must be <code>String</code>
    * <li>For a multi valued, non localized field, it must be <code>List&lt;String&gt;</code>
@@ -328,24 +328,25 @@ public class XPathMapper implements InvocationHandler {
     if (binding.multiLanguage()) {
       if (!method.getReturnType().isAssignableFrom(Map.class)) {
         throw new XPathMappingException(
-            "Method return type must be " + RETURN_TYPE_MULTI_LANGUAGE_SINGLE_VALUE + " if multiLanguage=true");
+            "Method return type must be " + RETURN_TYPE_MULTI_LANGUAGE_SINGLE_VALUE
+                + " if multiLanguage=true");
       }
       return;
     }
 
     // If we use a multiLanguage field, we ensure, that the return type is Map<Locale,String> or Map<Locale,List<String>>
     if (method.getReturnType().isAssignableFrom(Map.class)) {
-      String genericReturnTypeName=method.getGenericReturnType().getTypeName();
+      String genericReturnTypeName = method.getGenericReturnType().getTypeName();
 
-      if (!genericReturnTypeName.equals(RETURN_TYPE_MULTI_LANGUAGE_SINGLE_VALUE) &&
-          !genericReturnTypeName.equals(RETURN_TYPE_MULTI_LANGUAGE_MULTI_VALUE)) {
+      if (!genericReturnTypeName.equals(RETURN_TYPE_MULTI_LANGUAGE_SINGLE_VALUE)
+          && !genericReturnTypeName.equals(RETURN_TYPE_MULTI_LANGUAGE_MULTI_VALUE)) {
         throw new XPathMappingException("Method return type for multiLanguage fields must be "
             + RETURN_TYPE_MULTI_LANGUAGE_SINGLE_VALUE + " or "
             + RETURN_TYPE_MULTI_LANGUAGE_MULTI_VALUE + ", but not "
             + method.getGenericReturnType().getTypeName());
       }
 
-      boolean isTemplated = binding.valueTemplate().length()>0;
+      boolean isTemplated = binding.valueTemplate().length() > 0;
       if (isTemplated) {
         // Templates are only allowed on single valued return fields
         if (!genericReturnTypeName.equals(RETURN_TYPE_MULTI_LANGUAGE_SINGLE_VALUE)) {

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -1,17 +1,19 @@
 package de.digitalcollections.commons.xml.xpath;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.InputStream;
 import java.util.Locale;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+@DisplayName("The XPath Mapper")
 public class XPathMapperTest {
 
   private TestMapper mapper;
@@ -45,6 +47,31 @@ public class XPathMapperTest {
 
     @XPathBinding(valueTemplate = "{broken}", variables = {})
     String broken() throws XPathMappingException;
+
+    @XPathBinding(
+        defaultNamespace = TEI_NS,
+        multiLanguage = true,
+        expressions = {
+            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+        }
+    )
+    Map<Locale, String> getAuthorFromExpression() throws XPathMappingException;
+
+    @XPathBinding(
+        defaultNamespace = TEI_NS,
+        valueTemplate = "{author}",
+        multiLanguage = true,
+        variables = {
+            @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"})
+        },
+        expressions = {
+            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+        }
+    )
+    Map<Locale, String> getAuthorFromExpressionAndVariables() throws XPathMappingException;
+
+    @XPathBinding()
+    String getNothing() throws XPathMappingException;
   }
 
   @BeforeEach
@@ -57,19 +84,41 @@ public class XPathMapperTest {
     this.mapper = XPathMapper.makeProxy(doc, TestMapper.class);
   }
 
+  @DisplayName("shall evaluate a template with a single variable")
   @Test
   public void testTemplateWithSingleVariable() throws Exception {
     assertThat(mapper.getAuthor().get(Locale.GERMAN)).isEqualTo("Kugelmann, Hans");
     assertThat(mapper.getAuthor().get(Locale.ENGLISH)).isEqualTo("Name, English");
   }
 
+  @DisplayName("shall evaluate a template with context")
   @Test
   public void testTemplateWithContext() throws Exception {
     assertThat(mapper.getTitle()).isEqualTo("Ein Titel: Ein Untertitel");
   }
 
+  @DisplayName("shall throw an exception, when a template variable is missing")
   @Test
   public void testMissingVariableThrows() throws Exception {
     assertThatThrownBy(mapper::broken).isInstanceOf(XPathMappingException.class).hasMessageContaining("Could not resolve variable");
+  }
+
+  @DisplayName("shall evaluate an expression without template")
+  @Test
+  public void testExpression() throws Exception {
+    assertThat(mapper.getAuthorFromExpression().get(Locale.GERMAN)).isEqualTo("Kugelmann, Hans");
+    assertThat(mapper.getAuthorFromExpression().get(Locale.ENGLISH)).isEqualTo("Name, English");
+  }
+
+  @DisplayName("shall throw an exception, when templates and expressions are used at the same time")
+  @Test
+  public void testTemplatesAndExpressionsThrowException() {
+    assertThatThrownBy(mapper::getAuthorFromExpressionAndVariables).isInstanceOf(XPathMappingException.class).hasMessageContaining("Only one XPath evaluation type");
+  }
+
+  @DisplayName("shall throw an exception, when neither templares nor expressions are defined")
+  @Test
+  public void testNoTemplatesAndExpressionsThrowException() {
+    assertThatThrownBy(mapper::getNothing).isInstanceOf(XPathMappingException.class).hasMessageContaining("Either variables or expressions must be used");
   }
 }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -52,7 +52,7 @@ public class XPathMapperTest {
         defaultNamespace = TEI_NS,
         multiLanguage = true,
         expressions = {
-            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+            BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"
         }
     )
     Map<Locale, String> getAuthorFromExpression() throws XPathMappingException;
@@ -65,7 +65,7 @@ public class XPathMapperTest {
             @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"})
         },
         expressions = {
-            "BIBLSTRUCT_PATH + \"/tei:monogr/tei:author/tei:persName/tei:name"
+            BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"
         }
     )
     Map<Locale, String> getAuthorFromExpressionAndVariables() throws XPathMappingException;

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -231,31 +231,24 @@ public class XPathMapperTest {
   @DisplayName("shall throw an exception, when the return type of a single valued field is wrong")
   @Test
   public void testWrongReturnTypeOfSingleValuedFieldsThrowsException() {
-    assertThatThrownBy(mapper::wrongReturnTypeSinglevalued).isInstanceOf(XPathMappingException.class).hasMessageContaining("Method return for single valued single language fields must be java.lang.String");
+    assertThatThrownBy(mapper::wrongReturnTypeSinglevalued).isInstanceOf(XPathMappingException.class).hasMessageContaining("Binding method has illegal return type");
   }
 
   @DisplayName("shall throw an exception, when the return type of a multivalued field is wrong")
   @Test
   public void testWrongReturnTypeOfMultiValuedFieldsThrowsException() {
-    assertThatThrownBy(mapper::wrongReturnTypeMultivalued).isInstanceOf(XPathMappingException.class).hasMessageContaining("Method return type for multivalued single language fields");
+    assertThatThrownBy(mapper::wrongReturnTypeMultivalued).isInstanceOf(XPathMappingException.class).hasMessageContaining("Binding method has illegal return type");
   }
 
   @DisplayName("shall throw an exception, when the return type of a multilanguage field is wrong")
   @Test
   public void testWrongReturnTypeOfMultilanguageFieldsThrowsException() {
-    assertThatThrownBy(mapper::wrongReturnTypeMultiLanguage).isInstanceOf(XPathMappingException.class).hasMessageContaining("Method return type for multiLanguage fields must be java.util.Map");
-  }
-
-
-  @DisplayName("shall throw an exception, when the return type of a explicitly defined multilanguage field is wrong")
-  @Test
-  public void testWrongReturnTypeOfExplicitMultilanguageFieldsThrowsException() {
-    assertThatThrownBy(mapper::wrongReturnTypeExplicitMultiLanguage).isInstanceOf(XPathMappingException.class).hasMessageContaining("Method return type must be java.util.Map");
+    assertThatThrownBy(mapper::wrongReturnTypeMultiLanguage).isInstanceOf(XPathMappingException.class).hasMessageContaining("Binding method has illegal return type");
   }
 
   @DisplayName("shall throw an exception, when the return type of a multilanguage field is wrong in templated context")
   @Test
   public void testWrongReturnTypeOfMultilanguageFieldsInTemplatesThrowsException() {
-    assertThatThrownBy(mapper::wrongReturnTypeTemplatedMultiLanguage).isInstanceOf(XPathMappingException.class).hasMessageContaining("Method return type for templated multiLanguageFields must be");
+    assertThatThrownBy(mapper::wrongReturnTypeTemplatedMultiLanguage).isInstanceOf(XPathMappingException.class).hasMessageContaining("Templated binding methods must have a java.lang.String");
   }
 }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.InputStream;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,6 +73,16 @@ public class XPathMapperTest {
 
     @XPathBinding()
     String getNothing() throws XPathMappingException;
+
+    @XPathBinding(
+        defaultNamespace = TEI_NS,
+        multiValue = true,
+        expressions = {
+            BIBLSTRUCT_PATH + "/tei:monogr/tei:imprint/tei:pubPlace"
+        }
+    )
+    // or LinkedHashSet??
+    Set<String> getPlaces() throws XPathMappingException;
   }
 
   @BeforeEach
@@ -120,5 +131,11 @@ public class XPathMapperTest {
   @Test
   public void testNoTemplatesAndExpressionsThrowException() {
     assertThatThrownBy(mapper::getNothing).isInstanceOf(XPathMappingException.class).hasMessageContaining("Either variables or expressions must be used");
+  }
+
+  @DisplayName("shall return multivalued contents in the same order as in the bind")
+  @Test
+  public void testMultivaluedFieldsAndTheirOder() throws Exception {
+    assertThat(mapper.getPlaces()).containsExactly("Augsburg","München","Aachen");
   }
 }

--- a/dc-commons-xml/src/test/resources/bsbstruc.xml
+++ b/dc-commons-xml/src/test/resources/bsbstruc.xml
@@ -31,6 +31,10 @@
             <monogr>
               <title level="m" type="main">Ein Titel</title>
               <title level="m" type="sub">Ein Untertitel</title>
+              <title level="m" type="alt" subtype="main" xml:id="bsb00050852_titleAlt_01" xml:lang="en">Chuck Norris Biography</title>
+              <title level="m" type="alt" subtype="main" xml:id="bsb00050852_titleAlt_02" xml:lang="en">Facts</title>
+              <title level="m" type="alt" subtype="main" xml:id="bsb00050852_titleAlt_01" xml:lang="de">Chuck Norris Biographie</title>
+              <title level="m" type="alt" subtype="main" xml:id="bsb00050852_titleAlt_02" xml:lang="de">Fakten</title>
               <author>
                 <persName>
                   <name xml:lang="de">Kugelmann, Hans</name>

--- a/dc-commons-xml/src/test/resources/bsbstruc.xml
+++ b/dc-commons-xml/src/test/resources/bsbstruc.xml
@@ -45,6 +45,8 @@
               </respStmt>
               <imprint>
                 <pubPlace xml:id="bsb00050852_pubPlace01">Augsburg</pubPlace>
+                <pubPlace xml:id="bsb00050852_pubPlace02">München</pubPlace>
+                <pubPlace xml:id="bsb00050852_pubPlace03">Aachen</pubPlace>
                 <publisher>unbekannt</publisher>
                 <date type="pub">[1540]</date>
               </imprint>


### PR DESCRIPTION
This PR implements the ability to return `List<String>` for multivalued fields (plain fields and multi language fields) for expressions, but not in templates.