### PR TITLE
Introducing @XPathRoot annotation for brevity

### DIFF
--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/UniversalNamespaceContext.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/UniversalNamespaceContext.java
@@ -19,7 +19,11 @@ public class UniversalNamespaceContext implements NamespaceContext {
     this.customPrefixes = new HashMap<>();
   }
 
-  /** Add a user-defined namespace. Takes precedence over the document's declared namespaces. */
+  /**
+   * Add a user-defined namespace. Takes precedence over the document's declared namespaces.
+   * @param prefix the prefix
+   * @param uri the uri
+   */
   public void addNamespace(String prefix, String uri) {
     this.customPrefixes.put(prefix, uri);
   }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/UniversalNamespaceContext.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/UniversalNamespaceContext.java
@@ -21,8 +21,8 @@ public class UniversalNamespaceContext implements NamespaceContext {
 
   /**
    * Add a user-defined namespace. Takes precedence over the document's declared namespaces.
-   * @param prefix the prefix
-   * @param uri the uri
+   * @param prefix the namespace prefix
+   * @param uri the namespace uri
    */
   public void addNamespace(String prefix, String uri) {
     this.customPrefixes.put(prefix, uri);

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -5,19 +5,48 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation for retrieving content by XPath expressions
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XPathBinding {
+
+  /*
+   * A value template consists of a string with one or more placeholders ({@link XPathVariable
+   * .name()}) in brackets, e.g.
+   * <code>{author}</code> and additional characters inbetween. Parts, which are surrounded by
+   * angle brackets are optional, which means, their contents are left out, when the
+   * placeholder is not filled.
+   * <p>
+   * Example: <code>{title}lt;: {subtitle}&gt;&lt; [. {partNumber}&lt;, {partTitle}&gt;]&gt;</code>
+   * @return the value template definition. (optional)
+   */
   String valueTemplate() default "";
+
+  /**
+   * @return the default namespace, e.g. <code>http://www.tei-c.org/ns/1.0"</code> (optional)
+   */
   String defaultNamespace() default "";
 
   /**
    * @deprecated
    * Specifying the return type is sufficient, this field will be removed in future and is simply ignored for now.
+   *
+   * @return optional flag, if multi language evaluation is requested.
    */
   @Deprecated
   boolean multiLanguage() default false;
 
+  /**
+   * @return a set of {@link XPathVariable} annotations (optional). If you use a value template, you
+   *     must define the variables.
+   */
   XPathVariable[] variables() default {};
+
+  /**
+   * @return a set of XPath expressions (optional). Use this instead of {@link variables}, if you
+   *     don't use templating.
+   */
   String[] expressions() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -62,7 +62,7 @@ public class XPathMapper implements InvocationHandler {
       defaultRootNamespace = xpathRoot.defaultNamespace();
     } else {
       // If no root paths are set, we use / as default root path
-      rootPaths = new HashSet<>(Arrays.asList(new String[]{"/"}));
+      rootPaths = new HashSet<>(Arrays.asList(new String[]{""}));
       defaultRootNamespace = "";
     }
   }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
@@ -1,0 +1,14 @@
+package de.digitalcollections.commons.xml.xpath;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface XPathRoot {
+  String defaultNamespace() default "";
+  String[] value() default {};
+}

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
@@ -6,9 +6,27 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotation to set the default namespace and path prefixes for all
+ * subsequent {@link XPathBinding} annotations.
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XPathRoot {
+
+  /**
+   * @return the default namespace, e.g. <code>http://www.tei-c.org/ns/1.0"</code> (optional)
+   */
   String defaultNamespace() default "";
+
+  /**
+   * @return an array of path prefixes, e.g. <code>/tei:TEI/tei:teiHeader/tei:fileDesc/tei
+   *     :sourceDesc/tei:listBibl/tei:biblStruct</code>, which will be prepended to all
+   *     paths and expressions of the subsequent {@link XPathBinding} annotations.
+   *     <p>
+   *     Each path prefix will be prepended to each path of the bindings.
+   *     <p>
+   *     This field is optional, too. If unset, a blank root path is used.
+   */
   String[] value() default {};
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
@@ -20,13 +20,12 @@ public @interface XPathRoot {
   String defaultNamespace() default "";
 
   /**
-   * @return an array of path prefixes, e.g. <code>/tei:TEI/tei:teiHeader/tei:fileDesc/tei
+   * Definition of path prefixes, e.g. <code>/tei:TEI/tei:teiHeader/tei:fileDesc/tei
    *     :sourceDesc/tei:listBibl/tei:biblStruct</code>, which will be prepended to all
    *     paths and expressions of the subsequent {@link XPathBinding} annotations.
-   *     <p>
-   *     Each path prefix will be prepended to each path of the bindings.
-   *     <p>
-   *     This field is optional, too. If unset, a blank root path is used.
+   *
+   *     <p>Each path prefix will be prepended to each path of the bindings.
+   * @return an array of path prefixes (optional; if unset, a blank root path prefix is used)
    */
   String[] value() default {};
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathVariable.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathVariable.java
@@ -3,8 +3,22 @@ package de.digitalcollections.commons.xml.xpath;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * Annotation to define XPathVariables for templating.
+ * <p>
+ * An XPathVariable consists of its name (used for template placeholders)
+ * and an array of associated XPath expressions.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XPathVariable {
+
+  /**
+   * @return the name of the XPathVariable
+   */
   String name();
+
+  /**
+   * @return an Array of XPath expressions
+   */
   String[] paths();
 }


### PR DESCRIPTION
This PR introduces the @XPathRoot annotation as Type level, which allows not only shorter @XPathBindings on the methods, but also prepares an API for later caching of subtrees.

Example usage:
```java
@XPathRoot(
    defaultNamespace = "http://www.tei-c.org/ns/1.0",
    value = { "/tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:listBibl/tei:biblStruct" }
)
private interface XPathRootMapper {

  @XPathBinding(
      expressions = { "/tei:monogr/tei:author/tei:persName/tei:name"}
  )
  String getAuthor() throws XPathMappingException;
}