### PR TITLE
Hierarchy

### DIFF
--- a/dc-commons-xml/pom.xml
+++ b/dc-commons-xml/pom.xml
@@ -10,7 +10,7 @@
 
   <name>DigitalCollections: Commons XML</name>
   <artifactId>dc-commons-xml</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <properties>

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -12,6 +12,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XPathBinding {
 
+  /**
+   * @return a set of XPath expressions (optional). Use this instead of {@link variables}, if you
+   *     don't use templating.
+   */
+  String[] value() default "";
+
   /*
    * A value template consists of a string with one or more placeholders ({@link XPathVariable
    * .name()}) in brackets, e.g.
@@ -25,28 +31,8 @@ public @interface XPathBinding {
   String valueTemplate() default "";
 
   /**
-   * @return the default namespace, e.g. <code>http://www.tei-c.org/ns/1.0"</code> (optional)
-   */
-  String defaultNamespace() default "";
-
-  /**
-   * @deprecated
-   * Specifying the return type is sufficient, this field will be removed in future and is simply ignored for now.
-   *
-   * @return optional flag, if multi language evaluation is requested.
-   */
-  @Deprecated
-  boolean multiLanguage() default false;
-
-  /**
    * @return a set of {@link XPathVariable} annotations (optional). If you use a value template, you
    *     must define the variables.
    */
   XPathVariable[] variables() default {};
-
-  /**
-   * @return a set of XPath expressions (optional). Use this instead of {@link variables}, if you
-   *     don't use templating.
-   */
-  String[] expressions() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -63,7 +63,7 @@ public class XPathMapper implements InvocationHandler {
   }
 
   @SuppressWarnings("unchecked")
-  public static <T> T makeProxy(Document doc, Class<? extends T> iface, Set<String>rootPaths,
+  public static <T> T makeProxy(Document doc, Class<? extends T> iface, Set<String> rootPaths,
       String defaultRootNamespace) {
 
     return (T) Proxy.newProxyInstance(iface.getClassLoader(), new Class[]{iface}, new XPathMapper(doc,

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -72,7 +72,7 @@ public class XPathMapper implements InvocationHandler {
 
   private XPathMapper(Document doc, String[] rootPaths, String defaultRootNamespace) {
     this.xpw = new XPathWrapper(doc);
-    this.rootPaths = new HashSet<>(Arrays.asList(prependWithRootPaths(rootPaths)));
+    this.rootPaths = new HashSet<>(Arrays.asList(rootPaths));
     this.defaultRootNamespace = defaultRootNamespace;
   }
 

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
@@ -13,12 +13,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XPathRoot {
-
-  /**
-   * @return the default namespace, e.g. <code>http://www.tei-c.org/ns/1.0"</code> (optional)
-   */
-  String defaultNamespace() default "";
-
   /**
    * Definition of path prefixes, e.g. <code>/tei:TEI/tei:teiHeader/tei:fileDesc/tei
    *     :sourceDesc/tei:listBibl/tei:biblStruct</code>, which will be prepended to all
@@ -30,4 +24,10 @@ public @interface XPathRoot {
    * @return an array of path prefixes (optional; if unset, a blank root path prefix is used)
    */
   String[] value() default {};
+
+  /**
+   * The default namespace is only allowed on type level, not on methods.
+   * @return the default namespace, e.g. <code>http://www.tei-c.org/ns/1.0"</code> (optional)
+   */
+  String defaultNamespace() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathRoot.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
  * Annotation to set the default namespace and path prefixes for all
  * subsequent {@link XPathBinding} annotations.
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XPathRoot {
 
@@ -25,6 +25,8 @@ public @interface XPathRoot {
    *     paths and expressions of the subsequent {@link XPathBinding} annotations.
    *
    *     <p>Each path prefix will be prepended to each path of the bindings.
+   *
+   *     <p>Parent root paths are prepended.
    * @return an array of path prefixes (optional; if unset, a blank root path prefix is used)
    */
   String[] value() default {};

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -12,6 +12,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.w3c.dom.Document;
 
 @DisplayName("The XPath Mapper")
@@ -21,16 +22,17 @@ public class XPathMapperTest {
   private XPathRootMapper xPathRootMapper;
   private OuterMapper hierarchicalMapper;
   private BrokenOuterMapper brokenHierarchicalMapper;
+  private BrokenNamespacedOuterMapper brokenNamespacedOuterMapper;
 
+  @XPathRoot(
+      defaultNamespace = "http://www.tei-c.org/ns/1.0"
+  )
   private interface TestMapper {
 
-    String TEI_NS = "http://www.tei-c.org/ns/1.0";
     String BIBLSTRUCT_PATH = "/tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/tei:listBibl/tei:biblStruct";
 
     @XPathBinding(
-            defaultNamespace = TEI_NS,
             valueTemplate = "{author}",
-            multiLanguage = true,
             variables = {
               @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"})
             }
@@ -38,7 +40,6 @@ public class XPathMapperTest {
     Map<Locale, String> getAuthor() throws XPathMappingException;
 
     @XPathBinding(
-        defaultNamespace = TEI_NS,
         valueTemplate = "{author}",
         variables = {
             @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author[@type=\"ChuckNorris\"]/tei:persName/tei:name"})
@@ -47,7 +48,6 @@ public class XPathMapperTest {
     String getNoAuthor() throws XPathMappingException;
 
     @XPathBinding(
-            defaultNamespace = TEI_NS,
             valueTemplate = "{title}<: {subtitle}>< [. {partNumber}<, {partTitle}>]>",
             variables = {
               @XPathVariable(name = "title", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:title[@type=\"main\"]"}),
@@ -58,92 +58,49 @@ public class XPathMapperTest {
     )
     String getTitle() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        expressions = {
-            BIBLSTRUCT_PATH + "/tei:monogr/tei:title[@type=\"alt\" and @subtype=\"main\"]"
-        }
-    )
+    @XPathBinding(BIBLSTRUCT_PATH + "/tei:monogr/tei:title[@type=\"alt\" and @subtype=\"main\"]")
     Map<Locale,List<String>> getMultlangAlternativeTitles() throws XPathMappingException;
 
     @XPathBinding(valueTemplate = "{broken}", variables = {})
     String broken() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        multiLanguage = true,
-        expressions = {
-            BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"
-        }
-    )
+    @XPathBinding(BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name")
     Map<Locale, String> getAuthorFromExpression() throws XPathMappingException;
 
     @XPathBinding(
-        defaultNamespace = TEI_NS,
         valueTemplate = "{author}",
-        multiLanguage = true,
         variables = {
             @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"})
         },
-        expressions = {
-            BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"
-        }
+        value = BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"
     )
     Map<Locale, String> getAuthorFromExpressionAndVariables() throws XPathMappingException;
 
     @XPathBinding()
     String getNothing() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        expressions = {
-            BIBLSTRUCT_PATH + "/tei:monogr/tei:imprint/tei:pubPlace"
-        }
-    )
+    @XPathBinding(BIBLSTRUCT_PATH + "/tei:monogr/tei:imprint/tei:pubPlace")
     List<String> getPlaces() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        expressions = {
-            BIBLSTRUCT_PATH + "/tei:monogr/tei:imprint/tei:pubPlace[1]"
-        }
-    )
+    @XPathBinding(BIBLSTRUCT_PATH + "/tei:monogr/tei:imprint/tei:pubPlace[1]")
     String getFirstPlace() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        expressions = {
-            BIBLSTRUCT_PATH + "/tei:monogr/tei:imprint/tei:noPlace[1]"
-        }
-    )
+    @XPathBinding(BIBLSTRUCT_PATH + "/tei:monogr/tei:imprint/tei:noPlace[1]")
     String getNoPlace() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        expressions = {"/tei:TEI/tei:facsimile/tei:surface/@xml:id[1]"}
-    )
+    @XPathBinding("/tei:TEI/tei:facsimile/tei:surface/@xml:id[1]")
     Integer wrongReturnTypeSinglevalued() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        expressions = {"/tei:TEI/tei:facsimile/tei:surface/@xml:id"}
-    )
+    @XPathBinding("/tei:TEI/tei:facsimile/tei:surface/@xml:id")
     List<Integer> wrongReturnTypeMultivalued() throws XPathMappingException;
 
-    @XPathBinding(
-        defaultNamespace = TEI_NS,
-        expressions = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"}
-    )
+    @XPathBinding(BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name")
     Map<Locale, Integer> wrongReturnTypeMultiLanguage() throws XPathMappingException;
 
-    @XPathBinding(
-        multiLanguage = true,
-        expressions = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"}
-    )
+    @XPathBinding(BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name")
     String wrongReturnTypeExplicitMultiLanguage() throws XPathMappingException;
 
     @XPathBinding(
-        defaultNamespace = TEI_NS,
         valueTemplate = "{author}",
         variables = {
             @XPathVariable(name = "author", paths = {BIBLSTRUCT_PATH + "/tei:monogr/tei:author/tei:persName/tei:name"})
@@ -158,9 +115,7 @@ public class XPathMapperTest {
   )
   private interface XPathRootMapper {
 
-    @XPathBinding(
-        expressions = { "/tei:monogr/tei:author/tei:persName/tei:name"}
-    )
+    @XPathBinding("/tei:monogr/tei:author/tei:persName/tei:name")
     String getAuthor() throws XPathMappingException;
 
     @XPathBinding(
@@ -180,13 +135,10 @@ public class XPathMapperTest {
 
   @XPathRoot("/ignored")
   private interface InnerMapper {
-      @XPathBinding(
-          expressions = "/author"
-      )
-    String getAuthor();
+      @XPathBinding("/author")
+      String getAuthor();
   }
 
-  @XPathRoot("/outer")
   private interface BrokenOuterMapper {
     @XPathRoot("/inner")
     BrokenInnerMapper getInnerMapper() throws XPathMappingException;
@@ -194,6 +146,22 @@ public class XPathMapperTest {
 
   private interface BrokenInnerMapper {
     String someMethod() throws XPathMappingException;
+  }
+
+  @XPathRoot(
+      value = "/outer",
+      defaultNamespace = "http://www.tei-c.org/ns/1.0")
+  private interface BrokenNamespacedOuterMapper {
+    @XPathRoot(
+        value = "/inner",
+        defaultNamespace = "foo"
+    )
+    BrokenNamespacedInnerMapper getInnerMapper() throws XPathMappingException;;
+  }
+
+  private interface BrokenNamespacedInnerMapper {
+    @XPathBinding("/author")
+    String getAuthor() throws XPathMappingException;;
   }
 
   @BeforeEach
@@ -211,6 +179,9 @@ public class XPathMapperTest {
     this.hierarchicalMapper = XPathMapper.makeProxy(simpleDoc, OuterMapper.class);
 
     this.brokenHierarchicalMapper = XPathMapper.makeProxy(simpleDoc, BrokenOuterMapper.class);
+
+    this.brokenNamespacedOuterMapper = XPathMapper.makeProxy(simpleDoc,
+        BrokenNamespacedOuterMapper.class);
   }
 
   @DisplayName("shall evaluate a template with a single variable")
@@ -243,19 +214,6 @@ public class XPathMapperTest {
   @Test
   public void testSingleValueExpression() throws Exception {
     assertThat(mapper.getFirstPlace()).isEqualTo("Augsburg");
-  }
-
-  @DisplayName("shall evaluate a single value expression with root path defined in type")
-  @Test
-  public void testSingleValueExpressionWithXPathRoot() throws Exception {
-    assertThat(xPathRootMapper.getAuthor()).isEqualTo("Kugelmann, Hans");
-  }
-
-  @DisplayName("shall evaluate a template with a single variable and root path defined in type")
-  @Test
-  public void testTemplateWithSingleVariableAndXPathRoot() throws Exception {
-    assertThat(xPathRootMapper.getAuthors().get(Locale.GERMAN)).isEqualTo("Kugelmann, Hans");
-    assertThat(xPathRootMapper.getAuthors().get(Locale.ENGLISH)).isEqualTo("Name, English");
   }
 
   @DisplayName("shall return multivalued contents in the same order as in the bind")
@@ -331,5 +289,14 @@ public class XPathMapperTest {
   @Test
   public void shallPassDownRootPathsOnHierarchies() {
     assertThat(hierarchicalMapper.getInnerMapper().getAuthor()).isEqualTo("Chuck Norris");
+  }
+
+  @DisplayName("shall throw an exception, when embedding and embedded mappers both set a default "
+      + "namespace")
+  @Test
+  public void testHierarchyWithConflicingDefaultNamespaces() {
+    assertThatThrownBy(brokenNamespacedOuterMapper::getInnerMapper)
+        .isInstanceOf(XPathMappingException.class).hasMessageContaining(
+        "Default namespace can only be set on type level @XPathRoot annotation, not on method level.");
   }
 }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -12,7 +12,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.w3c.dom.Document;
 
 @DisplayName("The XPath Mapper")

--- a/dc-commons-xml/src/test/resources/simple.xml
+++ b/dc-commons-xml/src/test/resources/simple.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<outer>
+  <inner>
+    <author>Chuck Norris</author>
+  </inner>
+</outer>


### PR DESCRIPTION
Dieser MR führt ein neues Major Release ein, weil es zu einem API-Bruch kommt. Dieser ist nötig, weil jetzt XPathMappings sowohl kürzer, als auch weniger mißverständlich geschrieben werden können, insbesondere wenn eine XPathRoot-Definition ins Spiel kommt.

Hauptfeature dieses MR ist, dass es möglich ist, eine Hierarchie an Mappingklassen einzuführen, also in einer äußeren Mappingklasse beispielsweise den default Namespace und einen äußeren root-Pfad zu deklarieren, welcher dann von den inneren Mappingklassen (als Methoden) übernommen wird.

Beispiel:

```java
@XPathRoot("/outer")
private interface OuterMapper {
    @XPathRoot("/inner")
    InnerMapper getInnerMapper();
}

@XPathRoot("/ignored")
private interface InnerMapper {
    @XPathBinding("/author")
    String getAuthor();
}
```

Der author wird hierbei über den XPath `/outer/inner/author` ermittelt. 

Würde der InnerMapper alleine verwendet werden, so würde in diesem Fall der Autor
über den XPath `/ignored/author` ermittelt werden.

**Wichtig**: XPathRoot ist jetzt nur noch in Type-Definitionen und bei Methoden erlaubt, welche selber wieder Mapping-Interfaces zurückgeben.