### PR TITLE
WIP: Introducing Maps with anchestor values as keys

### DIFF
--- a/dc-commons-xml/pom.xml
+++ b/dc-commons-xml/pom.xml
@@ -15,6 +15,7 @@
   
   <properties>
     <version.assertj>3.15.0</version.assertj>
+    <version.commons-lang3>3.10</version.commons-lang3>
     <version.guava>28.2-jre</version.guava>
     <version.junit>5.6.1</version.junit>
     <version.saxon>10.0</version.saxon>
@@ -31,6 +32,11 @@
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
       <version>${version.saxon}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${version.commons-lang3}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
@@ -55,7 +55,7 @@ class DocumentReader {
 
     LinkedHashMap<String, String> valueMap = new LinkedHashMap<>();
     Map<Object, List<Object>> multiValueMap =
-        resolveVariableWithKeyPath(expressions.toArray(new String[] {}), true, false, keyPath);
+        resolveVariableWithKeyPath(expressions.toArray(new String[] {}), false, false, keyPath);
     multiValueMap.forEach(
         (k, v) -> valueMap.put((String) k, v.isEmpty() ? null : ((String) v.get(0)).trim()));
     return valueMap;
@@ -66,10 +66,23 @@ class DocumentReader {
 
     LinkedHashMap<String, Element> valueMap = new LinkedHashMap<>();
     Map<Object, List<Object>> multiValueMap =
-        resolveVariableWithKeyPath(expressions.toArray(new String[] {}), true, true, keyPath);
+        resolveVariableWithKeyPath(expressions.toArray(new String[] {}), false, true, keyPath);
     multiValueMap.forEach(
         (k, v) -> valueMap.put((String) k, v.isEmpty() ? null : (Element) v.get(0)));
     return valueMap;
+  }
+
+  public Map<String, List<String>> readMultiValueMap(List<String> expressions, String keyPath)
+      throws XPathMappingException {
+    LinkedHashMap<String, List<String>> valuesMap = new LinkedHashMap<>();
+    Map<Object, List<Object>> multiValueMap =
+        resolveVariableWithKeyPath(expressions.toArray(new String[] {}), true, false, keyPath);
+    multiValueMap.forEach(
+        (k, v) ->
+            valuesMap.put(
+                (String) k,
+                v.isEmpty() ? null : v.stream().map(String::valueOf).collect(Collectors.toList())));
+    return valuesMap;
   }
 
   public Map<Locale, String> readLocalizedValue(List<String> expressions)

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
@@ -16,8 +16,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.xml.xpath.XPathExpressionException;
-import org.apache.commons.lang3.ObjectUtils.Null;
-import org.apache.commons.lang3.tuple.Pair;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -45,23 +43,28 @@ class DocumentReader {
   }
 
   public String readValue(List<String> expressions) throws XPathMappingException {
-    return variableResolver.resolveVariable(
-        null,
-        expressions,
-        keynode -> null,
-        valuenode -> valuenode.getTextContent().replace("<", "\\<").replace(">", "\\>")
-        ).stream().map(p -> p.getRight())
+    return variableResolver
+        .resolveVariable(
+            null,
+            expressions,
+            keynode -> null,
+            valuenode -> valuenode.getTextContent().replace("<", "\\<").replace(">", "\\>"))
+        .stream()
+        .map(p -> p.getRight())
         .findFirst()
         .orElse(null);
   }
 
   public List<String> readValues(List<String> expressions) throws XPathMappingException {
-    return variableResolver.resolveVariable(
-        null,
-        expressions,
-        keynode -> null,
-        valuenodes -> valuenodes.getTextContent().replace("<", "\\<").replace(">", "\\>"))
-      .stream().map(pair -> pair.getRight()).collect(Collectors.toList());
+    return variableResolver
+        .resolveVariable(
+            null,
+            expressions,
+            keynode -> null,
+            valuenodes -> valuenodes.getTextContent().replace("<", "\\<").replace(">", "\\>"))
+        .stream()
+        .map(pair -> pair.getRight())
+        .collect(Collectors.toList());
   }
 
   public Map<String, String> readValueMap(List<String> expressions, String keyPath)

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.commons.xml.xpath;
 
-import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,18 +53,22 @@ class DocumentReader {
   public Map<String, String> readValueMap(List<String> expressions, String keyPath)
       throws XPathMappingException {
 
-    LinkedHashMap<String,String> valueMap = new LinkedHashMap<>();
-    Map<Object, List<Object>> multiValueMap = resolveVariableWithKeyPath(expressions.toArray(new String[] {}), true, false, keyPath);
-    multiValueMap.forEach((k, v) -> valueMap.put((String)k, v.isEmpty() ? null : ((String)v.get(0)).trim()));
+    LinkedHashMap<String, String> valueMap = new LinkedHashMap<>();
+    Map<Object, List<Object>> multiValueMap =
+        resolveVariableWithKeyPath(expressions.toArray(new String[] {}), true, false, keyPath);
+    multiValueMap.forEach(
+        (k, v) -> valueMap.put((String) k, v.isEmpty() ? null : ((String) v.get(0)).trim()));
     return valueMap;
   }
 
   public Map<String, Element> readElementValueMap(List<String> expressions, String keyPath)
       throws XPathMappingException {
 
-    LinkedHashMap<String,Element> valueMap = new LinkedHashMap<>();
-    Map<Object, List<Object>> multiValueMap = resolveVariableWithKeyPath(expressions.toArray(new String[] {}), true, true, keyPath);
-    multiValueMap.forEach((k, v) -> valueMap.put((String)k, v.isEmpty() ? null : (Element)v.get(0)));
+    LinkedHashMap<String, Element> valueMap = new LinkedHashMap<>();
+    Map<Object, List<Object>> multiValueMap =
+        resolveVariableWithKeyPath(expressions.toArray(new String[] {}), true, true, keyPath);
+    multiValueMap.forEach(
+        (k, v) -> valueMap.put((String) k, v.isEmpty() ? null : (Element) v.get(0)));
     return valueMap;
   }
 
@@ -239,16 +242,18 @@ class DocumentReader {
   private Map<Locale, List<String>> resolveVariable(String[] paths, boolean multiValued)
       throws XPathMappingException {
     Map<Locale, List<String>> ret = new LinkedHashMap<>();
-    resolveVariableWithKeyPath(paths, multiValued, false,null).forEach(
-        (k, v) -> ret.put((Locale)k,
-            new ArrayList<String>(v.stream().map(String.class::cast)
-                                .collect(Collectors.toList()))
-        )
-    );
+    resolveVariableWithKeyPath(paths, multiValued, false, null)
+        .forEach(
+            (k, v) ->
+                ret.put(
+                    (Locale) k,
+                    new ArrayList<String>(
+                        v.stream().map(String.class::cast).collect(Collectors.toList()))));
     return ret;
   }
 
-  private Map<Object, List<Object>> resolveVariableWithKeyPath(String[] paths, boolean multiValued, boolean returnNode, String keyPath)
+  private Map<Object, List<Object>> resolveVariableWithKeyPath(
+      String[] paths, boolean multiValued, boolean returnNode, String keyPath)
       throws XPathMappingException {
     paths = prependWithRootPaths(paths);
     Map<Object, List<Object>> result = new LinkedHashMap<>();
@@ -260,7 +265,7 @@ class DocumentReader {
         throw new XPathMappingException("Failed to resolve XPath: " + path, e);
       }
       for (Node node : nodes) {
-        Object key=null;
+        Object key = null;
         if (keyPath == null) {
           if (node.hasAttributes()) {
             Node langCode = node.getAttributes().getNamedItem("xml:lang");
@@ -268,7 +273,7 @@ class DocumentReader {
               key = determineLocaleFromCode(langCode.getNodeValue());
             }
           }
-          if (key == null || ((Locale)key).getLanguage().isEmpty()) {
+          if (key == null || ((Locale) key).getLanguage().isEmpty()) {
             key = determineLocaleFromCode("");
           }
         } else {

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
@@ -16,6 +16,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.xml.xpath.XPathExpressionException;
+import org.apache.commons.lang3.ObjectUtils.Null;
+import org.apache.commons.lang3.tuple.Pair;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -26,12 +28,16 @@ class DocumentReader {
   private final List<String> rootPaths;
   private final XPathWrapper xpw;
 
+  private final VariableResolver variableResolver;
+
   public DocumentReader(Document doc, List<String> rootPaths, String namespace) {
     this.rootPaths = rootPaths;
     this.xpw = new XPathWrapper(doc);
     if (namespace != null) {
       xpw.setDefaultNamespace(namespace);
     }
+
+    variableResolver = new VariableResolver(rootPaths, xpw);
   }
 
   public Document getDocument() {
@@ -39,15 +45,23 @@ class DocumentReader {
   }
 
   public String readValue(List<String> expressions) throws XPathMappingException {
-    return resolveVariable(expressions.toArray(new String[] {})).values().stream()
+    return variableResolver.resolveVariable(
+        null,
+        expressions,
+        keynode -> null,
+        valuenode -> valuenode.getTextContent().replace("<", "\\<").replace(">", "\\>")
+        ).stream().map(p -> p.getRight())
         .findFirst()
         .orElse(null);
   }
 
   public List<String> readValues(List<String> expressions) throws XPathMappingException {
-    return readLocalizedValues(expressions).values().stream()
-        .flatMap(List::stream)
-        .collect(Collectors.toList());
+    return variableResolver.resolveVariable(
+        null,
+        expressions,
+        keynode -> null,
+        valuenodes -> valuenodes.getTextContent().replace("<", "\\<").replace(">", "\\>"))
+      .stream().map(pair -> pair.getRight()).collect(Collectors.toList());
   }
 
   public Map<String, String> readValueMap(List<String> expressions, String keyPath)

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/TemplateHandler.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/TemplateHandler.java
@@ -1,0 +1,159 @@
+package de.digitalcollections.commons.xml.xpath;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.xml.xpath.XPathExpressionException;
+
+/**
+ * The purpose of this class is to handle templates, mainly to fill the templated with priovided
+ * values.
+ */
+public class TemplateHandler {
+
+  private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{([a-zA-Z0-9_-]+?)}");
+
+  /**
+   * Split a templateString into its embedded variables. Each variable must match the RegEx <code>
+   * {([a-zA-Z0-9_-]+?)}</code>
+   *
+   * @param templateString
+   * @return Set of extracted variables of the templateString
+   */
+  public Set<String> getVariables(String templateString) {
+    Matcher matcher = VARIABLE_PATTERN.matcher(templateString);
+    Set<String> variables = new HashSet<>();
+    while (matcher.find()) {
+      variables.add(matcher.group(1));
+    }
+    return variables;
+  }
+
+  /**
+   * Fills the variables of a templateString with the provided resolved variables.
+   *
+   * @param templateString The template string
+   * @param resolvedVariables A Map of resolved variables with the variable names as keys and the
+   *     values of a <code>Map&lt;Locale, String></code>.
+   * @return A localised value map.
+   * @throws XPathExpressionException
+   */
+  public Map<Locale, String> execute(
+      String templateString, Map<String, Map<Locale, String>> resolvedVariables)
+      throws XPathExpressionException {
+    Set<Locale> langs =
+        resolvedVariables.values().stream()
+            .map(Map::keySet) // Get set of languages for each resolved variable
+            .flatMap(Collection::stream) // Flatten these sets into a single stream
+            .collect(
+                Collectors.toCollection(
+                    LinkedHashSet::new)); // Store the stream in a set (thereby pruning duplicates)
+
+    Map<Locale, String> out = new LinkedHashMap<>();
+    // Resolve the <...> contexts
+    for (Locale lang : langs) {
+      String stringRepresentation = templateString;
+      String context = extractContext(stringRepresentation);
+      while (context != null) {
+        stringRepresentation =
+            stringRepresentation.replace(
+                "<" + context + ">", resolveVariableContext(lang, context, resolvedVariables));
+        context = extractContext(stringRepresentation);
+      }
+
+      // Now we just need to resolve top-level variables
+      Matcher matcher = VARIABLE_PATTERN.matcher(stringRepresentation);
+      while (matcher.find()) {
+        String varName = matcher.group(1);
+        if (resolvedVariables.get(varName).isEmpty()) {
+          return null;
+        }
+        Locale langToResolve;
+        if (resolvedVariables.get(varName).containsKey(lang)) {
+          langToResolve = lang;
+        } else {
+          langToResolve = resolvedVariables.get(varName).entrySet().iterator().next().getKey();
+        }
+        stringRepresentation =
+            stringRepresentation.replace(
+                matcher.group(), resolvedVariables.get(varName).get(langToResolve));
+        matcher = VARIABLE_PATTERN.matcher(stringRepresentation);
+      }
+
+      // And un-escape the pointy brackets
+      out.put(lang, stringRepresentation.replace("\\<", "<").replace("\\>", ">"));
+    }
+    return out;
+  }
+
+  private String extractContext(String template) throws XPathExpressionException {
+    StringBuilder ctx = new StringBuilder();
+    boolean isEscaped = false;
+    boolean wasOpened = false;
+    int numOpen = 0;
+    for (char c : template.toCharArray()) {
+      if (c == '\\') {
+        isEscaped = true;
+        if (numOpen > 0) {
+          ctx.append(c);
+        }
+      } else if (c == '<') {
+        if (numOpen > 0) {
+          ctx.append(c);
+        }
+        if (!isEscaped) {
+          numOpen++;
+          if (!wasOpened) {
+            wasOpened = true;
+          }
+        } else {
+          isEscaped = false;
+        }
+      } else if (c == '>') {
+        if ((numOpen > 0 && isEscaped) || numOpen > 1) {
+          ctx.append(c);
+        }
+        if (!isEscaped) {
+          numOpen--;
+          if (numOpen == 0) {
+            return ctx.toString();
+          }
+        } else {
+          isEscaped = false;
+        }
+      } else if (wasOpened) {
+        ctx.append(c);
+      }
+    }
+    if (wasOpened) {
+      throw new XPathExpressionException(
+          String.format(
+              "Mismatched context delimiters, %s were unclosed at the end of parsing.", numOpen));
+    } else {
+      return null;
+    }
+  }
+
+  private String resolveVariableContext(
+      Locale language, String variableContext, Map<String, Map<Locale, String>> resolvedVariables) {
+    Matcher varMatcher = VARIABLE_PATTERN.matcher(variableContext);
+    varMatcher.find();
+    String variableName = varMatcher.group(1);
+    Map<Locale, String> resolvedValues = resolvedVariables.get(variableName);
+    if (resolvedValues == null || resolvedValues.isEmpty()) {
+      return "";
+    } else if (resolvedValues.containsKey(language)) {
+      return variableContext.replace(varMatcher.group(), resolvedValues.get(language));
+    } else {
+      return variableContext.replace(
+          varMatcher.group(), resolvedValues.entrySet().iterator().next().getValue());
+    }
+  }
+}

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
@@ -1,12 +1,21 @@
 package de.digitalcollections.commons.xml.xpath;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.w3c.dom.Node;
 
+/**
+ * This class extracts key/value tuples out of an XML document by their XPaths.
+ *
+ * <p>The <code>paths</code> are always absolute (and prepended with the root paths, if they were
+ * provided in the constructor), the paths for the keys must be relative, to establish the
+ * connection to the resolved items.
+ */
 public class VariableResolver {
 
   private final List<String> rootPaths;
@@ -17,6 +26,30 @@ public class VariableResolver {
     this.xpw = xpw;
   }
 
+  /**
+   * A generic method to resolve a given list of paths and to extract their values. For referencing,
+   * for each value a <code>Pair</code> is returned with a key, calculated as described below, and
+   * the value.
+   *
+   * <p>If the keyPath is set (to an XPath expression relative to the current path), the key value
+   * is calculated by the <code>keyTransformer</code>, which gets the key node as input.
+   *
+   * <p>If the keyPath is <code>null</code>, the <code>keyTransfomer</code> must also return a key
+   * (e.g. randomized), but gets <code>null</code> as input.
+   *
+   * @param keyPath The relative path, of whose node the key is calculated from. If the key is of no
+   *     use, the path can be <code>null</code>, but then the <code>keyTransformer</code> function
+   *     must return a random value for a <code>null</code> input.
+   * @param paths The XPath expressions, where the values are retrieved from. If one or <code>
+   *     rootPaths</code> are set in the constructor of this class, they are prepended (and
+   *     multiplied, if more than one) to the XPath expressions.
+   * @param keyTransformer a function to transform a key node into a key of the expected type
+   * @param valueTransformer a function to transform a value node into a value of the expected type
+   * @param <K> the type of the key
+   * @param <V> the type of the value
+   * @return a list of key/value pairs
+   * @throws XPathMappingException when the value node could not be resolved.
+   */
   public <K, V> List<Pair<K, V>> resolveVariable(
       String keyPath,
       List<String> paths,
@@ -37,8 +70,11 @@ public class VariableResolver {
       }
 
       for (Node node : nodes) {
-        K key = null;
-        if (keyPath != null) {
+        K key;
+        if (keyPath == null) {
+          // The keyTransformer alone must return the key.
+          key = keyTransformer.apply(null);
+        } else {
           Node keyNode = xpw.asNode(node, keyPath);
           key = keyTransformer.apply(keyNode);
         }
@@ -60,5 +96,66 @@ public class VariableResolver {
     return paths.stream()
         .flatMap(e -> rootPaths.stream().map(r -> r + e))
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Extract the payload string(s) from a node by traversing down the node to all its childs in the
+   * order, given by the DOM.
+   *
+   * @param node the start node
+   * @return A linked list (ordered by the order of the children in the DOM) with all text node
+   *     contents in the subtree
+   */
+  public List<String> extractStringListFromNode(Node node) {
+    List<String> ret = new LinkedList<>();
+    if (node.getNodeType() == Node.TEXT_NODE) {
+      ret.add(node.getTextContent());
+      return ret;
+    }
+
+    for (int i = 0; i < node.getChildNodes().getLength(); i++) {
+      ret.addAll(extractStringListFromNode(node.getChildNodes().item(i)));
+    }
+    return ret;
+  }
+
+  /**
+   * Extract the locale information from a node, based on the value of the <code>xml:lang</code>
+   * attribute.
+   *
+   * @param node the noode
+   * @return the Locale or null
+   */
+  public Locale extractLocaleFromNode(Node node) {
+    Node langCode = node.getAttributes().getNamedItem("xml:lang");
+    if (langCode != null) {
+      return determineLocaleFromCode(langCode.getNodeValue());
+    }
+    return null;
+  }
+
+  protected static Locale determineLocaleFromCode(String localeCode) {
+    if (localeCode == null) {
+      return null;
+    }
+
+    Locale locale = Locale.forLanguageTag(localeCode);
+    if (!locale.getLanguage().isEmpty()) {
+      return locale;
+    }
+
+    // For cases, in which the language could not be determined
+    // (e.g. for "und"), we have to re-build the locale manually
+    String[] localeCodeParts = localeCode.split("-");
+    if (localeCodeParts.length == 1) {
+      // We only have a language, probably "und"
+      return new Locale.Builder().setLanguage(localeCodeParts[0]).build();
+    } else {
+      // We have language and script
+      return new Locale.Builder()
+          .setLanguage(localeCodeParts[0])
+          .setScript(localeCodeParts[1])
+          .build();
+    }
   }
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
@@ -1,18 +1,14 @@
 package de.digitalcollections.commons.xml.xpath;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.checkerframework.checker.units.qual.K;
 import org.w3c.dom.Node;
 
-public class VariableResolver{
+public class VariableResolver {
 
   private final List<String> rootPaths;
   private final XPathWrapper xpw;
@@ -22,11 +18,12 @@ public class VariableResolver{
     this.xpw = xpw;
   }
 
-  public <K,V> List<Pair<K, V>> resolveVariable(
+  public <K, V> List<Pair<K, V>> resolveVariable(
       String keyPath,
       List<String> paths,
       Function<Node, K> keyTransformer,
-      Function<Node, V> valueTransformer) throws XPathMappingException {
+      Function<Node, V> valueTransformer)
+      throws XPathMappingException {
 
     List<Pair<K, V>> resolvedVariables = new ArrayList<>();
 
@@ -54,7 +51,6 @@ public class VariableResolver{
     }
 
     return resolvedVariables;
-
   }
 
   private List<String> prependWithRootPaths(List<String> paths) {

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
@@ -1,0 +1,69 @@
+package de.digitalcollections.commons.xml.xpath;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.checkerframework.checker.units.qual.K;
+import org.w3c.dom.Node;
+
+public class VariableResolver{
+
+  private final List<String> rootPaths;
+  private final XPathWrapper xpw;
+
+  public VariableResolver(List<String> rootPaths, XPathWrapper xpw) {
+    this.rootPaths = rootPaths;
+    this.xpw = xpw;
+  }
+
+  public <K,V> List<Pair<K, V>> resolveVariable(
+      String keyPath,
+      List<String> paths,
+      Function<Node, K> keyTransformer,
+      Function<Node, V> valueTransformer) throws XPathMappingException {
+
+    List<Pair<K, V>> resolvedVariables = new ArrayList<>();
+
+    paths = prependWithRootPaths(paths);
+
+    for (String path : paths) {
+      List<Node> nodes;
+      try {
+        nodes = xpw.asListOfNodes(path);
+      } catch (IllegalArgumentException e) {
+        throw new XPathMappingException("Failed to resolve XPath: " + path, e);
+      }
+
+      for (Node node : nodes) {
+        K key = null;
+        if (keyPath != null) {
+          Node keyNode = xpw.asNode(node, keyPath);
+          key = keyTransformer.apply(keyNode);
+        }
+
+        V value = valueTransformer.apply(node);
+
+        resolvedVariables.add(Pair.of(key, value));
+      }
+    }
+
+    return resolvedVariables;
+
+  }
+
+  private List<String> prependWithRootPaths(List<String> paths) {
+    if (rootPaths == null || rootPaths.isEmpty()) {
+      return paths;
+    }
+
+    return paths.stream()
+        .flatMap(e -> rootPaths.stream().map(r -> r + e))
+        .collect(Collectors.toList());
+  }
+}

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/VariableResolver.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
-import org.checkerframework.checker.units.qual.K;
 import org.w3c.dom.Node;
 
 public class VariableResolver {

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -33,4 +33,9 @@ public @interface XPathBinding {
    *     must define the variables.
    */
   XPathVariable[] variables() default {};
+
+  /**
+   * @Return an XPath expression (optional), whose value is used as key for a result map
+   */
+  String keyPath() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathBinding.java
@@ -34,8 +34,6 @@ public @interface XPathBinding {
    */
   XPathVariable[] variables() default {};
 
-  /**
-   * @Return an XPath expression (optional), whose value is used as key for a result map
-   */
+  /** @Return an XPath expression (optional), whose value is used as key for a result map */
   String keyPath() default "";
 }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathMapper.java
@@ -321,7 +321,6 @@ public class XPathMapper<T> {
     private final List<String> paths;
     private final String keyPath;
 
-
     public SimpleField(Method m, String[] paths, String keyPath) throws XPathMappingException {
       super(m);
       this.paths = Arrays.asList(paths);
@@ -347,7 +346,12 @@ public class XPathMapper<T> {
       this.multiLanguage = isMultiLocalized || isSingleLocalized;
       this.multiValued = isMultiValued || isMultiLocalized || keyPathStringMap || keyPathElementMap;
       this.multiValuedElements = MULTIVALUED_ELEMENT_TYPE.isSubtypeOf(targetType);
-      if (!multiLanguage && !multiValued && !multiValuedElements && !isSingleValued && !keyPathStringMap && !keyPathElementMap) {
+      if (!multiLanguage
+          && !multiValued
+          && !multiValuedElements
+          && !isSingleValued
+          && !keyPathStringMap
+          && !keyPathElementMap) {
         throw new XPathMappingException(
             String.format(
                 "Binding method has illegal target type %s, must be one of %s, %s, %s, %s, %s, %s or %s",

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/VariableResolverTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/VariableResolverTest.java
@@ -7,18 +7,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("The document reader")
-class DocumentReaderTest {
+class VariableResolverTest {
 
   @DisplayName("returns null for a locale with code null")
   @Test
   public void testNullLocale() {
-    assertThat(DocumentReader.determineLocaleFromCode(null)).isNull();
+    assertThat(VariableResolver.determineLocaleFromCode(null)).isNull();
   }
 
   @DisplayName("returns a locale with language and without script when only the language is given")
   @Test
   public void testLanguageOnlyLocale() {
-    Locale loc = DocumentReader.determineLocaleFromCode("de");
+    Locale loc = VariableResolver.determineLocaleFromCode("de");
     assertThat(loc.getLanguage()).isEqualTo("de");
     assertThat(loc.getScript()).isEmpty();
   }
@@ -26,7 +26,7 @@ class DocumentReaderTest {
   @DisplayName("handles unknown languages properly")
   @Test
   public void testUnknownLanguages() {
-    Locale loc = DocumentReader.determineLocaleFromCode("und");
+    Locale loc = VariableResolver.determineLocaleFromCode("und");
     assertThat(loc.getLanguage()).isEqualTo("und");
     assertThat(loc.getScript()).isEmpty();
   }
@@ -34,7 +34,7 @@ class DocumentReaderTest {
   @DisplayName("returns a locale with language and script for known locale codes")
   @Test
   public void testKnownLocaleCodes() {
-    Locale loc = DocumentReader.determineLocaleFromCode("zh-Hani");
+    Locale loc = VariableResolver.determineLocaleFromCode("zh-Hani");
     assertThat(loc.getLanguage()).isEqualTo("zh");
     assertThat(loc.getScript()).isEqualTo("Hani");
   }
@@ -42,7 +42,7 @@ class DocumentReaderTest {
   @DisplayName("returns a locale with language and script for unknown locale codes")
   @Test
   public void testUnknownLocaleCodes() {
-    Locale loc = DocumentReader.determineLocaleFromCode("und-Latn");
+    Locale loc = VariableResolver.determineLocaleFromCode("und-Latn");
     assertThat(loc.getLanguage()).isEqualTo("und");
     assertThat(loc.getScript()).isEqualTo("Latn");
   }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -17,6 +17,8 @@ public class XPathMapperTest {
       "/TEI/teiHeader/fileDesc/sourceDesc/listBibl/biblStruct";
 
   XPathMapperFixture<TestMapper> testMapperFixture = new XPathMapperFixture<>(TestMapper.class);
+  XPathMapperFixture<MultTestMapper> multTestMapperFixture =
+      new XPathMapperFixture<>(MultTestMapper.class);
   XPathMapperFixture<BrokenTestMapper> brokenTestMapperFixture =
       new XPathMapperFixture<>(BrokenTestMapper.class);
   XPathMapperFixture<BrokenStructuredTestMapper> brokenStructuredTestMapperFixture =
@@ -41,7 +43,6 @@ public class XPathMapperTest {
   XPathMapperFixture<BrokenHierarchicalMapper> brokenHierarchivalMapperFixture =
       new XPathMapperFixture<>(BrokenHierarchicalMapper.class);
 
-  /*
   @DisplayName("shall evaluate a template with a single variable for a field")
   @Test
   public void testClassTemplateWithSingleVariableForField() throws Exception {
@@ -116,7 +117,6 @@ public class XPathMapperTest {
     TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
     assertThat(mapper.getNoPlace()).isNull();
   }
-  */
 
   @DisplayName("shall use keys from anchestor node in return maps with simple types")
   @Test
@@ -132,6 +132,18 @@ public class XPathMapperTest {
     TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
     Map<String, Element> sequenceNumbers = mapper.getSequenceNumberElementsForSurface();
     assertThat(sequenceNumbers.get("bsb00050852_00467")).isNotNull();
+  }
+
+  @DisplayName("shall use keys from anchester node in return maps with lists")
+  @Test
+  public void testKeysFromAnchestorNodeInLists() throws Exception {
+    MultTestMapper mapper = multTestMapperFixture.setUpMapperWithResource("bsbmult.xml");
+    Map<String, List<String>> bindIdsForTitle = mapper.getBindIdsForTitle();
+    assertThat(bindIdsForTitle).hasSize(2);
+    assertThat(bindIdsForTitle.get("bsbmult00000000_h0001"))
+        .containsExactly("bsb00000001", "bsb00000002");
+    assertThat(bindIdsForTitle.get("bsbmult00000000_h0002"))
+        .containsExactly("bsb00000003", "bsb00000004", "bsb00000005");
   }
 
   @DisplayName("shall throw an exception, when a template variable is missing")
@@ -367,6 +379,19 @@ public class XPathMapperTest {
 
     Map<String, Element> getSequenceNumberElementsForSurface() {
       return sequenceNumberElementsForSurface;
+    }
+  }
+
+  @XPathRoot(defaultNamespace = "http://www.tei-c.org/ns/1.0")
+  public static class MultTestMapper {
+    @XPathBinding(
+        value =
+            "/tei:TEI/tei:text/tei:body/tei:div/tei:listBibl[@ana='#multTitle']/tei:biblStruct/tei:monogr/tei:biblScope[@unit='tome']/@corresp",
+        keyPath = "../../../../../@xml:id")
+    Map<String, List<String>> bindIdsForTitle;
+
+    Map<String, List<String>> getBindIdsForTitle() {
+      return bindIdsForTitle;
     }
   }
 

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -134,7 +134,7 @@ public class XPathMapperTest {
     assertThat(sequenceNumbers.get("bsb00050852_00467")).isNotNull();
   }
 
-  @DisplayName("shall use keys from anchester node in return maps with lists")
+  @DisplayName("shall use keys from anchestor node in return maps with lists")
   @Test
   public void testKeysFromAnchestorNodeInLists() throws Exception {
     MultTestMapper mapper = multTestMapperFixture.setUpMapperWithResource("bsbmult.xml");
@@ -362,8 +362,7 @@ public class XPathMapperTest {
     }
 
     @XPathBinding(
-        value =
-            "/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
+        value = "/TEI/facsimile[@ana='#facsScan']/surface/desc/list/item[@ana='#sequenceNo']",
         keyPath = "../../../@xml:id")
     Map<String, String> sequenceNumbersForSurface;
 
@@ -372,8 +371,7 @@ public class XPathMapperTest {
     }
 
     @XPathBinding(
-        value =
-            "/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
+        value = "/TEI/facsimile[@ana='#facsScan']/surface/desc/list/item[@ana='#sequenceNo']",
         keyPath = "../../../@xml:id")
     Map<String, Element> sequenceNumberElementsForSurface;
 
@@ -386,7 +384,7 @@ public class XPathMapperTest {
   public static class MultTestMapper {
     @XPathBinding(
         value =
-            "/tei:TEI/tei:text/tei:body/tei:div/tei:listBibl[@ana='#multTitle']/tei:biblStruct/tei:monogr/tei:biblScope[@unit='tome']/@corresp",
+            "/TEI/text/body/div/listBibl[@ana='#multTitle']/biblStruct/monogr/biblScope[@unit='tome']/@corresp",
         keyPath = "../../../../../@xml:id")
     Map<String, List<String>> bindIdsForTitle;
 

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -41,6 +41,7 @@ public class XPathMapperTest {
   XPathMapperFixture<BrokenHierarchicalMapper> brokenHierarchivalMapperFixture =
       new XPathMapperFixture<>(BrokenHierarchicalMapper.class);
 
+  /*
   @DisplayName("shall evaluate a template with a single variable for a field")
   @Test
   public void testClassTemplateWithSingleVariableForField() throws Exception {
@@ -114,6 +115,23 @@ public class XPathMapperTest {
   public void testNonmatchingExpressionReturnsNull() throws Exception {
     TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
     assertThat(mapper.getNoPlace()).isNull();
+  }
+  */
+
+  @DisplayName("shall use keys from anchestor node in return maps with simple types")
+  @Test
+  public void testKeysFromAnchestorNode() throws Exception {
+    TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
+    Map<String, String> sequenceNumbers = mapper.getSequenceNumbersForSurface();
+    assertThat(sequenceNumbers.get("bsb00050852_00467")).isEqualTo("467");
+  }
+
+  @DisplayName("shall use keys from anchestor node in return maps with Elements as values")
+  @Test
+  public void testKeysFromAnchestorNodeInElements() throws Exception {
+    TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
+    Map<String, Element> sequenceNumbers = mapper.getSequenceNumberElementsForSurface();
+    assertThat(sequenceNumbers.get("bsb00050852_00467")).isNotNull();
   }
 
   @DisplayName("shall throw an exception, when a template variable is missing")
@@ -329,6 +347,26 @@ public class XPathMapperTest {
 
     String getNoPlace() {
       return noPlace;
+    }
+
+    @XPathBinding(
+        value="/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
+        keyPath="../../../@xml:id"
+    )
+    Map<String, String> sequenceNumbersForSurface;
+
+    Map<String, String> getSequenceNumbersForSurface() {
+      return sequenceNumbersForSurface;
+    }
+
+    @XPathBinding(
+        value="/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
+        keyPath="../../../@xml:id"
+    )
+    Map<String, Element> sequenceNumberElementsForSurface;
+
+    Map<String, Element> getSequenceNumberElementsForSurface() {
+      return sequenceNumberElementsForSurface;
     }
   }
 

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -350,9 +350,9 @@ public class XPathMapperTest {
     }
 
     @XPathBinding(
-        value="/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
-        keyPath="../../../@xml:id"
-    )
+        value =
+            "/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
+        keyPath = "../../../@xml:id")
     Map<String, String> sequenceNumbersForSurface;
 
     Map<String, String> getSequenceNumbersForSurface() {
@@ -360,9 +360,9 @@ public class XPathMapperTest {
     }
 
     @XPathBinding(
-        value="/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
-        keyPath="../../../@xml:id"
-    )
+        value =
+            "/tei:TEI/tei:facsimile[@ana='#facsScan']/tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
+        keyPath = "../../../@xml:id")
     Map<String, Element> sequenceNumberElementsForSurface;
 
     Map<String, Element> getSequenceNumberElementsForSurface() {

--- a/dc-commons-xml/src/test/resources/bsbmult.xml
+++ b/dc-commons-xml/src/test/resources/bsbmult.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?xml-model href="http://rest.digitale-sammlungen.de/data/schema/bsbMult/1.1/bsbMult.odd" type="application/tei+xml" schematypens="http://www.tei-c.org/ns/1.0"?>
+<?xml-model href="http://rest.digitale-sammlungen.de/data/schema/bsbMult/1.1/bsbMult.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://rest.digitale-sammlungen.de/data/schema/bsbMult/1.1/bsbMult.rnc" type="application/relax-ng-compact-syntax"?>
+<?xml-model href="http://rest.digitale-sammlungen.de/data/schema/bsbMult/1.1/bsbMult.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://rest.digitale-sammlungen.de/data/schema/bsbMult/1.1/bsbMult.dtd" type="application/xml+dtd"?>
+
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="bsbmult000000000">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Der gerade Weg</title>
+      </titleStmt>
+      <publicationStmt>
+        <publisher>Bayerische Staatsbibliothek</publisher>
+        <availability>
+          <p>Öffentlich zugänglich auf den Servern der Digitalen Bibliothek</p>
+        </availability>
+      </publicationStmt>
+      <sourceDesc>
+        <biblStruct>
+          <monogr>
+            <title level="j" type="main">Übergeordneter Titel</title>
+          </monogr>
+        </biblStruct>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div xml:id="bsbmult00000000_h0001">
+        <listBibl ana="#multTitle">
+          <biblStruct>
+            <monogr>
+              <biblScope corresp="bsb00000001" unit="tome"/>
+              <biblScope corresp="bsb00000002" unit="tome"/>
+            </monogr>
+          </biblStruct>
+        </listBibl>
+      </div>
+      <div xml:id="bsbmult00000000_h0002">
+        <listBibl ana="#multTitle">
+          <biblStruct>
+            <monogr>
+              <biblScope corresp="bsb00000003" unit="tome"/>
+              <biblScope corresp="bsb00000004" unit="tome"/>
+              <biblScope corresp="bsb00000005" unit="tome"/>
+            </monogr>
+          </biblStruct>
+        </listBibl>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
This PR introduces the ability to return Maps with keys, whose values are calculated from the anchestors of the nodes.

Assuming, you have the following data structure
```xml
[...]
  <surface xml:id="abc">
    <desc>
      <list ana="#bsbIdent">
        <item ana="#sequenceNo">
          <num>123</num>
        </item>
      </list>
    </desc>  
  </surface>
```
You can now return a Map, which contains the entry `("abc","123")` with the following annotation:
```java
@XPathBinding(
        value =
            "........./tei:surface/tei:desc/tei:list/tei:item[@ana='#sequenceNo']",
        keyPath = "../../../@xml:id")
```
using the Type `Map<String, String>`.

It it also possible, to return the Element for the corresponding XPath by using the Type `Map<String, Element>` or to return a List of Strings by using the Type `Map<String, List<String>>`