### PR TITLE
Add locale/language data type (storing into VARCHAR)

### DIFF
--- a/dc-commons-jdbi/src/main/java/de/digitalcollections/commons/jdbi/DcCommonsJdbiPlugin.java
+++ b/dc-commons-jdbi/src/main/java/de/digitalcollections/commons/jdbi/DcCommonsJdbiPlugin.java
@@ -7,6 +7,8 @@ public class DcCommonsJdbiPlugin implements JdbiPlugin {
 
   @Override
   public void customizeJdbi(Jdbi db) {
+    db.registerArgument(new LocaleArgumentFactory());
+    db.registerColumnMapper(new LocaleColumnMapperFactory());
     db.registerArgument(new MimeTypeArgumentFactory());
     db.registerColumnMapper(new MimeTypeColumnMapperFactory());
     db.registerArgument(new UrlArgumentFactory());

--- a/dc-commons-jdbi/src/main/java/de/digitalcollections/commons/jdbi/LocaleArgumentFactory.java
+++ b/dc-commons-jdbi/src/main/java/de/digitalcollections/commons/jdbi/LocaleArgumentFactory.java
@@ -1,0 +1,20 @@
+package de.digitalcollections.commons.jdbi;
+
+import java.sql.Types;
+import java.util.Locale;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+public class LocaleArgumentFactory extends AbstractArgumentFactory<Locale> {
+
+  public LocaleArgumentFactory() {
+    super(Types.VARCHAR);
+  }
+
+  @Override
+  protected Argument build(Locale locale, ConfigRegistry config) {
+    return (position, preparedStatement, statementContext) ->
+        preparedStatement.setObject(position, locale.toLanguageTag(), Types.VARCHAR);
+  }
+}

--- a/dc-commons-jdbi/src/main/java/de/digitalcollections/commons/jdbi/LocaleColumnMapperFactory.java
+++ b/dc-commons-jdbi/src/main/java/de/digitalcollections/commons/jdbi/LocaleColumnMapperFactory.java
@@ -1,0 +1,26 @@
+package de.digitalcollections.commons.jdbi;
+
+import java.lang.reflect.Type;
+import java.util.Locale;
+import java.util.Optional;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.ColumnMapperFactory;
+
+public class LocaleColumnMapperFactory implements ColumnMapperFactory {
+
+  @Override
+  public Optional<ColumnMapper<?>> build(Type type, ConfigRegistry config) {
+    if (type == Locale.class) {
+      return Optional.ofNullable(
+          (resultSet, columnNumber, statementContext) -> {
+            final String localeString = resultSet.getString(columnNumber);
+            if (localeString == null) {
+              return null;
+            }
+            return Locale.forLanguageTag(localeString);
+          });
+    }
+    return Optional.empty();
+  }
+}


### PR DESCRIPTION
Add locale/language data type (storing into VARCHAR) as postgres has no Locale-Datatype.
Needed e.g. to be able to save language of an item.