### PR TITLE
Add support for mapping List<T> of nested types

### DIFF
--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -211,6 +211,30 @@ public class XPathMapperTest {
     HierarchicalMapper mapper = hierarchicalMapperFixture.setUpMapperWithResource("simple.xml");
     assertThat(mapper.getInnerMapper().getAuthor()).isEqualTo("Chuck Norris");
   }
+
+  @DisplayName("shall handle collections of nested types")
+  @Test
+  public void testNestedTypeCollections() throws XPathMappingException {
+    MultiNestedInnerRoot innerMapper =
+        new XPathMapperFixture<>(MultiNestedInnerRoot.class)
+            .setUpMapperWithResource("nested-multi.xml");
+    assertThat(innerMapper.persons).hasSize(3);
+    assertThat(innerMapper.persons.get(0))
+        .hasFieldOrPropertyWithValue("name", "Chuck Norris")
+        .hasFieldOrPropertyWithValue("id", "1337");
+    assertThat(innerMapper.persons.get(1))
+        .hasFieldOrPropertyWithValue("name", "Frank Zappa")
+        .hasFieldOrPropertyWithValue("id", "42");
+    assertThat(innerMapper.persons.get(2))
+        .hasFieldOrPropertyWithValue("name", "Bobby Brown")
+        .hasFieldOrPropertyWithValue("id", "1970");
+    MultiNestedOuterRoot outerMapper =
+        new XPathMapperFixture<>(MultiNestedOuterRoot.class)
+            .setUpMapperWithResource("nested-multi.xml");
+    assertThat(outerMapper.persons.get(2))
+        .hasFieldOrPropertyWithValue("name", "Bobby Brown")
+        .hasFieldOrPropertyWithValue("id", "1970");
+  }
   // ---------------------------------------------------------------------------------------------
 
   @XPathRoot(defaultNamespace = "http://www.tei-c.org/ns/1.0")
@@ -483,6 +507,33 @@ public class XPathMapperTest {
       String getAuthor() {
         return author;
       }
+    }
+  }
+
+  public static class MultiNestedInnerRoot {
+    @XPathRoot({"/outer/author", "/outer/character"})
+    public List<Person> persons;
+
+    public static class Person {
+      @XPathBinding("/name")
+      public String name;
+
+      @XPathBinding("/id")
+      public String id;
+    }
+  }
+
+  @XPathRoot("/outer")
+  public static class MultiNestedOuterRoot {
+    @XPathRoot({"/author", "/character"})
+    public List<Person> persons;
+
+    public static class Person {
+      @XPathBinding("/name")
+      public String name;
+
+      @XPathBinding("/id")
+      public String id;
     }
   }
 }

--- a/dc-commons-xml/src/test/resources/nested-multi.xml
+++ b/dc-commons-xml/src/test/resources/nested-multi.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<outer>
+  <author>
+    <id>1337</id>
+    <name>Chuck Norris</name>
+  </author>
+  <author>
+    <id>42</id>
+    <name>Frank Zappa</name>
+  </author>
+  <character>
+    <id>1970</id>
+    <name>Bobby Brown</name>
+  </character>
+</outer>


### PR DESCRIPTION
If a field or setter is annotated with `@XPathRoot` and its type is `List<T>`, where `T` is a type with mapping annotations of its own, the `XPathMapper` will now create instances of `T` from every element matching the paths in `XPathRoot`, using the sub-tree (with the matching
element as the root) for the mapping.

As an example, given the following XML:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<outer>
  <author>
    <id>1337</id>
    <name>Chuck Norris</name>
  </author>
  <author>
    <id>42</id>
    <name>Frank Zappa</name>
  </author>
  <character>
    <id>1970</id>
    <name>Bobby Brown</name>
  </character>
</outer>
```

these two mapping classes provide identical functionality:

```java
  public static class MultiNestedInnerRoot {
    @XPathRoot({"/outer/author", "/outer/character"})
    public List<Person> persons;

    public static class Person {
      @XPathBinding("/name")
      public String name;

      @XPathBinding("/id")
      public String id;
    }
  }
```

```java
  @XPathRoot("/outer")
  public static class MultiNestedOuterRoot {
    @XPathRoot({"/author", "/character"})
    public List<Person> persons;

    public static class Person {
      @XPathBinding("/name")
      public String name;

      @XPathBinding("/id")
      public String id;
    }
  }
```