### PR TITLE
Speedup for empty locale

### DIFF
--- a/dc-commons-xml/pom.xml
+++ b/dc-commons-xml/pom.xml
@@ -10,7 +10,7 @@
 
   <name>DigitalCollections: Commons XML</name>
   <artifactId>dc-commons-xml</artifactId>
-  <version>5.1.0</version>
+  <version>5.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <properties>


### PR DESCRIPTION
Für Nodes ohne Locale kann die Geschwindigkeit der Auswertung massiv gesteigert werden, wenn man deren Values in einer getrennten Liste vorhält.