### PR TITLE
Non-localized results no longer bound to Node lists (fixes #289)

### DIFF
--- a/dc-commons-xml/pom.xml
+++ b/dc-commons-xml/pom.xml
@@ -10,7 +10,7 @@
 
   <name>DigitalCollections: Commons XML</name>
   <artifactId>dc-commons-xml</artifactId>
-  <version>5.1.2-SNAPSHOT</version>
+  <version>5.1.2</version>
   <packaging>jar</packaging>
   
   <properties>

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -301,25 +300,31 @@ class DocumentReader {
     }
   }
 
+  // TODO Don't restrict to string lists
   private List<String> resolveVariablesAsStrings(String[] paths, boolean multiValued) {
-    List<String> result = new LinkedList<>();
+    List<String> result = new ArrayList<>();
     paths = prependWithRootPaths(paths);
 
     for (String path : paths) {
       for (Object resolvedObject : xpw.asListOfObjects(path)) {
+
         if (resolvedObject instanceof String && !((String) resolvedObject).isEmpty()) {
           result.add((String) resolvedObject);
+          continue;
         }
-        if (multiValued && resolvedObject instanceof DOMNodeList) {
+        if (resolvedObject instanceof Integer) {
+          continue;
+        }
+        if (resolvedObject instanceof DOMNodeList) {
           DOMNodeList nodeList = ((DOMNodeList) resolvedObject);
           for (int i = 0, l = nodeList.getLength(); i < l; i++) {
             String textContent = nodeList.item(i).getTextContent();
             if (textContent == null) {
               textContent = "";
             }
-            textContent = textContent.trim();
-            if (!result.contains(textContent)) {
-              result.add(textContent);
+            result.add(textContent.trim());
+            if (!multiValued) {
+              break;
             }
           }
         }

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
@@ -313,6 +313,7 @@ class DocumentReader {
           continue;
         }
         if (resolvedObject instanceof Integer) {
+          result.add(((Integer) resolvedObject).toString());
           continue;
         }
         if (resolvedObject instanceof DOMNodeList) {

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
@@ -4,6 +4,7 @@ import de.digitalcollections.commons.xml.namespaces.DigitalCollectionsNamespaceC
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 import javax.xml.namespace.NamespaceContext;
@@ -109,6 +110,18 @@ public class XPathWrapper {
       list.add(nodeList.item(i));
     }
     return list;
+  }
+
+  public List<Object> asListOfObjects(String xpath) {
+    List<Object> ret = new LinkedList<>();
+    ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.STRING));
+    ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.NUMBER));
+    ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.BOOLEAN));
+    try {
+      ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.NODESET));
+    } catch (Exception ignore) {
+    }
+    return ret;
   }
 
   /**

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathWrapper.java
@@ -112,14 +112,27 @@ public class XPathWrapper {
     return list;
   }
 
+  /**
+   * Evaluate every possible type, an XPathExpression can return
+   *
+   * @param xpath the xPath expression
+   * @return all possible xPath evaluations as a list of Objects
+   */
   public List<Object> asListOfObjects(String xpath) {
     List<Object> ret = new LinkedList<>();
-    ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.STRING));
-    ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.NUMBER));
-    ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.BOOLEAN));
     try {
       ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.NODESET));
-    } catch (Exception ignore) {
+    } catch (Exception noNodeset) {
+      // We have no NodeSet as return type, so we continue with the "flat" types
+      ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.STRING));
+      ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.NUMBER));
+      ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.BOOLEAN));
+      // ... and finally, we check, if the evaluation returns a single XPath node
+      try {
+        ret.add(evaluateXpath(getDocument(), xpath, XPathConstants.NODE));
+      } catch (Exception noNode) {
+        // to be ignored
+      }
     }
     return ret;
   }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -253,6 +253,23 @@ public class XPathMapperTest {
     assertThat(outerMapper.getEmptyXPathRootInnerRoot()).isNotNull();
     assertThat(outerMapper.getEmptyXPathRootInnerRoot().getXmlId()).isEqualTo("bsb00050852");
   }
+
+  @DisplayName(
+      "shall be able to evaluate statements, which return integer values by returning their string representation")
+  @Test
+  public void testStatementsWithIntegerResult() throws XPathMappingException {
+    TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
+    assertThat(mapper.getAmountPlaces()).isEqualTo(3);
+  }
+
+  @DisplayName(
+      "shall be able to evaluate statements, which return a node by returning its string representation")
+  @Test
+  public void testStatementsWithReturnNode() throws XPathMappingException {
+    TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
+    assertThat(mapper.getFirstPersNameNode()).contains("Kugelmann, Hans");
+    assertThat(mapper.getFirstPersNameNode()).contains("Name, English");
+  }
   // ---------------------------------------------------------------------------------------------
 
   @XPathRoot(defaultNamespace = "http://www.tei-c.org/ns/1.0")
@@ -379,6 +396,24 @@ public class XPathMapperTest {
 
     public String getDateScan() {
       return dateScan;
+    }
+
+    @XPathBinding("count(" + BIBLSTRUCT_PATH + "/monogr/imprint/pubPlace)")
+    void setAmountPlaces(String strAmountPlaces) {
+      this.amountPlaces = Integer.parseInt(strAmountPlaces);
+    }
+
+    int amountPlaces;
+
+    public int getAmountPlaces() {
+      return amountPlaces;
+    }
+
+    @XPathBinding(BIBLSTRUCT_PATH + "/monogr/author/persName[1]")
+    String firstPersNameNode;
+
+    public String getFirstPersNameNode() {
+      return firstPersNameNode;
     }
   }
 

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -92,6 +92,13 @@ public class XPathMapperTest {
     assertThat(mapper.getFirstPlace()).isEqualTo("Augsburg");
   }
 
+  @DisplayName("shall evaluate a single valued expression with a function")
+  @Test
+  public void testSingleValueExpressionWithFunction() throws Exception {
+    TestMapper mapper = testMapperFixture.setUpMapperWithResource("bsbstruc.xml");
+    assertThat(mapper.getDateScan()).isEqualTo("2019-11-19");
+  }
+
   @DisplayName("shall return multivalued contents in the same order as in the bind")
   @Test
   public void testMultivaluedFieldsAndTheirOrder() throws Exception {
@@ -364,6 +371,14 @@ public class XPathMapperTest {
 
     String getNoPlace() {
       return noPlace;
+    }
+
+    @XPathBinding(
+        "substring(/TEI/teiHeader/fileDesc/notesStmt/note[@type=\"digDate\"]/date[@ana=\"#scan\"]/@when,1,10)")
+    String dateScan;
+
+    public String getDateScan() {
+      return dateScan;
     }
   }
 

--- a/dc-commons-xml/src/test/resources/bsbstruc.xml
+++ b/dc-commons-xml/src/test/resources/bsbstruc.xml
@@ -25,6 +25,11 @@
           </p>
         </availability>
       </publicationStmt>
+      <notesStmt>
+        <note type="digDate">
+          <date when="2019-11-19T20:51:49" ana="#scan"/>
+        </note>
+      </notesStmt>
       <sourceDesc>
         <listBibl type="source">
           <biblStruct ana="#bsbStandard">


### PR DESCRIPTION
Für reine String-Rückgaben bzw. Rückgaben einer Liste von Strings wird nicht mehr der Sonderweg über die Lokalisierung eingeschlagen. Außerdem wird intern nicht mehr davon ausgegangen, dass die XPath-Evaluierung eine NodeList zurückgibt, sondern sie kann auch Strings, Numbers und Booleans zurückgeben, wobei die letzten beiden ignorieren können, da wir ausschließlich Strings als Rückgabe erlauben.