### PR TITLE
Draft: evaluate standard java xml instead saxon

### DIFF
--- a/dc-commons-xml/pom.xml
+++ b/dc-commons-xml/pom.xml
@@ -10,7 +10,7 @@
 
   <name>DigitalCollections: Commons XML</name>
   <artifactId>dc-commons-xml</artifactId>
-  <version>5.1.2</version>
+  <version>5.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <properties>
@@ -26,11 +26,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${version.guava}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.saxon</groupId>
-      <artifactId>Saxon-HE</artifactId>
-      <version>${version.saxon}</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/DocumentReader.java
@@ -16,10 +16,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.xml.xpath.XPathExpressionException;
-import net.sf.saxon.dom.DOMNodeList;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /** Helper class to read simple or templated values from an XML document. */
 class DocumentReader {
@@ -316,8 +316,8 @@ class DocumentReader {
           result.add(((Integer) resolvedObject).toString());
           continue;
         }
-        if (resolvedObject instanceof DOMNodeList) {
-          DOMNodeList nodeList = ((DOMNodeList) resolvedObject);
+        if (resolvedObject instanceof NodeList) {
+          NodeList nodeList = ((NodeList) resolvedObject);
           for (int i = 0, l = nodeList.getLength(); i < l; i++) {
             String textContent = nodeList.item(i).getTextContent();
             if (textContent == null) {

--- a/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathExpressionCache.java
+++ b/dc-commons-xml/src/main/java/de/digitalcollections/commons/xml/xpath/XPathExpressionCache.java
@@ -4,19 +4,16 @@ import de.digitalcollections.commons.xml.namespaces.DigitalCollectionsNamespaceC
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-import net.sf.saxon.xpath.XPathEvaluator;
-import net.sf.saxon.xpath.XPathFactoryImpl;
 
 public class XPathExpressionCache {
   private final ConcurrentHashMap<String, XPathExpression> cache;
 
-  private final XPathFactory xPathFactory = new XPathFactoryImpl();
+  private final XPathFactory xPathFactory = XPathFactory.newInstance();
   private final XPath xpath;
 
   public XPathExpressionCache() {
@@ -27,9 +24,10 @@ public class XPathExpressionCache {
     cache = new ConcurrentHashMap<>();
     xpath = xPathFactory.newXPath();
     xpath.setNamespaceContext(namespaceCtx);
-    ((XPathEvaluator) xpath)
-        .getStaticContext()
-        .setDefaultElementNamespace(namespaceCtx.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
+    //    ((XPathEvaluator) xpath)
+    //        .getStaticContext()
+    //
+    // .setDefaultElementNamespace(namespaceCtx.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
   }
 
   public XPathExpression get(String expression) {
@@ -68,9 +66,10 @@ public class XPathExpressionCache {
       final DigitalCollectionsNamespaceContext namespaceCtx =
           new DigitalCollectionsNamespaceContext(namespaceUri);
       xpath.setNamespaceContext(namespaceCtx);
-      ((XPathEvaluator) xpath)
-          .getStaticContext()
-          .setDefaultElementNamespace(namespaceCtx.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
+      //      ((XPathEvaluator) xpath)
+      //          .getStaticContext()
+      //
+      // .setDefaultElementNamespace(namespaceCtx.getNamespaceURI(XMLConstants.DEFAULT_NS_PREFIX));
     }
   }
 }

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/BasicTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/BasicTest.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.commons.xml.xpath;
 
-import de.digitalcollections.commons.xml.namespaces.DigitalCollectionsNamespaceContext;
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -9,8 +8,6 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-import net.sf.saxon.xpath.XPathEvaluator;
-import net.sf.saxon.xpath.XPathFactoryImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,11 +25,11 @@ public class BasicTest {
         Thread.currentThread().getContextClassLoader().getResourceAsStream("bsbstruc.xml");
     Document doc = db.parse(is);
 
-    XPathFactory xPathFactory = new XPathFactoryImpl();
+    XPathFactory xPathFactory = XPathFactory.newInstance();
     XPath xpath = xPathFactory.newXPath();
-    ((XPathEvaluator) xpath)
-        .getStaticContext()
-        .setDefaultElementNamespace(DigitalCollectionsNamespaceContext.TEI_NS_URI);
+    //    ((XPathEvaluator) xpath)
+    //        .getStaticContext()
+    //        .setDefaultElementNamespace(DigitalCollectionsNamespaceContext.TEI_NS_URI);
     XPathExpression expr = xpath.compile("/TEI/teiHeader/fileDesc/titleStmt/title");
     try {
       String title = (String) expr.evaluate(doc, XPathConstants.STRING);

--- a/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
+++ b/dc-commons-xml/src/test/java/de/digitalcollections/commons/xml/xpath/XPathMapperTest.java
@@ -286,7 +286,7 @@ public class XPathMapperTest {
 
     Map<Locale, String> getAuthor() {
       return author;
-    };
+    }
 
     List<Element> authorElements;
 


### PR DESCRIPTION
try to solve xpath "contains" problem by replacing saxon with standard java engine.
interrupted because other (java) solution implemented as workaround.
this branch kept as there may come a time without saxon....