### PR TITLE
commons-file: Add new FileSystemResourceIOException

### DIFF
--- a/dc-commons-file/pom.xml
+++ b/dc-commons-file/pom.xml
@@ -10,7 +10,7 @@
 
   <name>DigitalCollections: Commons File</name>
   <artifactId>dc-commons-file</artifactId>
-  <version>5.1.1-SNAPSHOT</version>
+  <version>5.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/FileSystemResourceIOException.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/FileSystemResourceIOException.java
@@ -1,0 +1,15 @@
+package de.digitalcollections.commons.file.backend;
+
+import de.digitalcollections.model.exception.ResourceIOException;
+
+/**
+ * A subtype of ResourceIOException to indicate that an honest-to-god actual IOException (as in
+ * harddisk broken, network share unavailable or a cosmic ray hit the CPU in just the right way for
+ * the syscall to fail.)
+ */
+public class FileSystemResourceIOException extends ResourceIOException {
+
+  public FileSystemResourceIOException(Throwable ex) {
+    super(ex);
+  }
+}

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/FileResourceRepository.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/FileResourceRepository.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.commons.file.backend.api;
 
+import de.digitalcollections.commons.file.backend.FileSystemResourceIOException;
 import de.digitalcollections.model.exception.ResourceIOException;
 import de.digitalcollections.model.exception.ResourceNotFoundException;
 import de.digitalcollections.model.file.MimeType;
@@ -46,6 +47,8 @@ public interface FileResourceRepository {
    * @param identifier identifier of FileResource, used to lookup URI for FileResource
    * @param mimeType mimetype of the FileResource
    * @return FileResource implementation matching mimetype and URI resolved using identifier.
+   * @throws FileSystemResourceIOException if there was a raw disk I/O error while locating the
+   *     resource
    * @throws ResourceIOException thrown if no URI can be resolved for FileResource with given
    *     mimetype and identifier
    * @throws ResourceNotFoundException thrown if FileResource at resolved URI does not exist
@@ -56,6 +59,8 @@ public interface FileResourceRepository {
   /**
    * @param resourceUri URI for accessing FileResource data
    * @return InputStream for reading FileResource data
+   * @throws FileSystemResourceIOException if there was a raw disk I/O error while locating the
+   *     resource
    * @throws ResourceIOException thrown if an IOExcpetion appears at reading FileResource data
    * @throws ResourceNotFoundException thrown if FileResource at resolved URI does not exist
    */
@@ -64,6 +69,8 @@ public interface FileResourceRepository {
   /**
    * @param resource FileResource containing URI for accessing FileResource data
    * @return InputStream for reading FileResource data
+   * @throws FileSystemResourceIOException if there was a raw disk I/O error while locating the
+   *     resource
    * @throws ResourceIOException thrown if an IOExcpetion appears at reading FileResource data
    * @throws ResourceNotFoundException thrown if FileResource at resolved URI does not exist
    */
@@ -73,6 +80,8 @@ public interface FileResourceRepository {
   /**
    * @param resource FileResource containing URI for accessing FileResource data
    * @return Reader for InputStream of FileResource data
+   * @throws FileSystemResourceIOException if there was a raw disk I/O error while locating the
+   *     resource
    * @throws ResourceIOException thrown if an IOExcpetion appears at reading FileResource data
    * @throws ResourceNotFoundException thrown if FileResource at resolved URI does not exist
    */


### PR DESCRIPTION
...to differentiate between "no readable resources found for identifier" and "potential resource found, but I/O error prevented us from completing the operation".

We want to differentiate downstream between the two (e.g. in a webservice the former would be a 404 and the latter a 500, raw disk i/o is definitely an internal server error).

We opted for subclassing the existing `ResourceIOException` as to not break the existing API.