### PR TITLE
Refactorings for using refactored builder patterns from dc-model

### DIFF
--- a/dc-commons-springmvc/CHANGELOG.md
+++ b/dc-commons-springmvc/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking** Use `digitalcollections-model` version 10, which introduces breaking changes for all builders
+
+
+
 ## [4.2.0](https://github.com/dbmdz/digitalcollections-commons/releases/tag/dc-commons-springmvc-4.2.0) - 2022-04-12
 
 ### Added

--- a/dc-commons-springmvc/pom.xml
+++ b/dc-commons-springmvc/pom.xml
@@ -10,12 +10,12 @@
 
   <name>DigitalCollections: Commons Spring MVC</name>
   <artifactId>dc-commons-springmvc</artifactId>
-  <version>4.2.0</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
     <version.assertj>3.22.0</version.assertj>
-    <version.dc-model>9.2.0</version.dc-model>
+    <version.dc-model>10.0.0-SNAPSHOT</version.dc-model>
     <version.guava>29.0-jre</version.guava>
     <version.junit>5.8.2</version.junit>
     <version.mockito-core>4.4.0</version.mockito-core>

--- a/dc-commons-springmvc/src/main/java/de/digitalcollections/commons/springmvc/converter/StringToOrderConverter.java
+++ b/dc-commons-springmvc/src/main/java/de/digitalcollections/commons/springmvc/converter/StringToOrderConverter.java
@@ -3,7 +3,6 @@ package de.digitalcollections.commons.springmvc.converter;
 import de.digitalcollections.model.paging.Direction;
 import de.digitalcollections.model.paging.NullHandling;
 import de.digitalcollections.model.paging.Order;
-import de.digitalcollections.model.paging.OrderBuilder;
 import de.digitalcollections.model.paging.Sorting;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,7 +28,7 @@ public class StringToOrderConverter implements Converter<String, Order> {
     if (!matcher.matches()) {
       return null;
     }
-    OrderBuilder order = Order.defaultBuilder();
+    Order.Builder order = Order.builder();
     String property = matcher.group("property");
     order.property(property);
     String subProperty = matcher.group("subProperty");


### PR DESCRIPTION
- Refactorings to use `dc-model` in version 10 with inner class builders