### PR TITLE
Fix dash in subproperty

### DIFF
--- a/dc-commons-springmvc/CHANGELOG.md
+++ b/dc-commons-springmvc/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Changed
+
+- StringToOrderConverter now allows subProperty containing dash "-" (e.g. "label=de-Latn")
+
 ## [6.0.0](https://github.com/dbmdz/digitalcollections-commons/releases/tag/dc-commons-springmvc-6.0.0) - 2022-07-18
 
 ### Changed

--- a/dc-commons-springmvc/pom.xml
+++ b/dc-commons-springmvc/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>dc-commons-springmvc</artifactId>
-  <version>6.0.0</version>
+  <version>6.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>DigitalCollections: Commons Spring MVC</name>

--- a/dc-commons-springmvc/src/main/java/de/digitalcollections/commons/springmvc/converter/StringToOrderConverter.java
+++ b/dc-commons-springmvc/src/main/java/de/digitalcollections/commons/springmvc/converter/StringToOrderConverter.java
@@ -20,7 +20,7 @@ public class StringToOrderConverter implements Converter<String, Order> {
       Pattern.compile(
           "^(?i)"
               + "(?<property>[a-z]+)"
-              + "(_(?<subProperty>[a-z]+))?"
+              + "(_(?<subProperty>[a-z\\-]+))?" // subProperty allowing a-z and dash "-"
               + "(\\.(?<direction>asc|desc))?"
               + "(\\.(?<nullHandling>nullsfirst|nullslast))?"
               + "(\\.(?<ignoreCase>ignorecase))?"

--- a/dc-commons-springmvc/src/test/java/de/digitalcollections/commons/springmvc/converter/StringToOrderConverterTest.java
+++ b/dc-commons-springmvc/src/test/java/de/digitalcollections/commons/springmvc/converter/StringToOrderConverterTest.java
@@ -51,6 +51,16 @@ public class StringToOrderConverterTest {
   }
 
   @Test
+  public void testConversionPropertySubProperty2() {
+    String source = "label_de-Latn";
+    Order converted = converter.convert(source);
+    assertThat(converted.getProperty()).isEqualTo("label");
+    assertThat(converted.getSubProperty()).isEqualTo(Optional.of("de-Latn"));
+    assertThat(converted.getDirection()).isEqualTo(Sorting.DEFAULT_DIRECTION);
+    assertThat(converted.getNullHandling()).isEqualTo(NullHandling.NATIVE);
+  }
+
+  @Test
   public void testConversionPropertyDirection() {
     String source = "lastModified.desc";
     Order converted = converter.convert(source);


### PR DESCRIPTION
StringToOrderConverter now allows subProperty containing dash "-" (e.g. "label=de-Latn")