### PR TITLE
Fix getUris check

### DIFF
--- a/dc-commons-file/pom.xml
+++ b/dc-commons-file/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>dc-commons-file</artifactId>
-  <version>6.0.0</version>
+  <version>6.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>DigitalCollections: Commons File</name>

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/IdentifierToFileResourceUriResolver.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/IdentifierToFileResourceUriResolver.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.commons.file.backend.api;
 
+import static de.digitalcollections.model.file.MimeType.MIME_APPLICATION_OCTET_STREAM;
+
 import de.digitalcollections.model.exception.ResourceIOException;
 import de.digitalcollections.model.file.MimeType;
 import java.net.URI;
@@ -59,7 +61,10 @@ public interface IdentifierToFileResourceUriResolver {
   default List<URI> getUris(String identifier, MimeType mimeType) throws ResourceIOException {
     final List<URI> uris = getUris(identifier);
     return uris.stream()
-        .filter(u -> (mimeType.matches(MimeType.fromURI(u)) || MimeType.fromURI(u) == null))
+        .filter(
+            u ->
+                (mimeType.matches(MimeType.fromURI(u))
+                    || MimeType.fromURI(u).equals(MIME_APPLICATION_OCTET_STREAM)))
         .collect(Collectors.toList());
   }
 

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/IdentifierToFileResourceUriResolver.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/api/IdentifierToFileResourceUriResolver.java
@@ -64,7 +64,7 @@ public interface IdentifierToFileResourceUriResolver {
         .filter(
             u ->
                 (mimeType.matches(MimeType.fromURI(u))
-                    || MimeType.fromURI(u).equals(MIME_APPLICATION_OCTET_STREAM)))
+                    || MIME_APPLICATION_OCTET_STREAM.equals(MimeType.fromURI(u))))
         .collect(Collectors.toList());
   }
 

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.commons.file.backend.impl;
 
+import static de.digitalcollections.model.file.MimeType.MIME_APPLICATION_OCTET_STREAM;
+
 import de.digitalcollections.commons.file.backend.api.IdentifierToFileResourceUriResolver;
 import de.digitalcollections.model.exception.ResourceIOException;
 import de.digitalcollections.model.file.MimeType;
@@ -130,7 +132,10 @@ public class IdentifierPatternToFileResourceUriResolverImpl
   public List<URI> getUris(String identifier, MimeType mimeType) throws ResourceIOException {
     final List<URI> uris = getUris(identifier);
     return uris.stream()
-        .filter(u -> (mimeType.matches(MimeType.fromURI(u)) || MimeType.fromURI(u) == null))
+        .filter(
+            u ->
+                (mimeType.matches(MimeType.fromURI(u))
+                    || MimeType.fromURI(u) == MIME_APPLICATION_OCTET_STREAM))
         .collect(Collectors.toList());
   }
 

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
@@ -135,7 +135,7 @@ public class IdentifierPatternToFileResourceUriResolverImpl
         .filter(
             u ->
                 (mimeType.matches(MimeType.fromURI(u))
-                    || MimeType.fromURI(u) == MIME_APPLICATION_OCTET_STREAM))
+                    || MimeType.fromURI(u).equals(MIME_APPLICATION_OCTET_STREAM)))
         .collect(Collectors.toList());
   }
 

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.commons.file.backend.impl;
 
-import static de.digitalcollections.model.file.MimeType.MIME_APPLICATION_OCTET_STREAM;
 
 import de.digitalcollections.commons.file.backend.api.IdentifierToFileResourceUriResolver;
 import de.digitalcollections.model.exception.ResourceIOException;
@@ -118,25 +117,6 @@ public class IdentifierPatternToFileResourceUriResolverImpl
   @Override
   public List<URI> getUris(String identifier) throws ResourceIOException {
     return getUrisAsStrings(identifier).stream().map(URI::create).collect(Collectors.toList());
-  }
-
-  /**
-   * Return resolved URIs that match the given MIME type.
-   *
-   * @param identifier file identifier/resolving key
-   * @param mimeType target mimetype (resolving subkey)
-   * @return list of resolved file uris
-   * @throws ResourceIOException in case getUrisAsStrings for key fails
-   */
-  @Override
-  public List<URI> getUris(String identifier, MimeType mimeType) throws ResourceIOException {
-    final List<URI> uris = getUris(identifier);
-    return uris.stream()
-        .filter(
-            u ->
-                (mimeType.matches(MimeType.fromURI(u))
-                    || MimeType.fromURI(u).equals(MIME_APPLICATION_OCTET_STREAM)))
-        .collect(Collectors.toList());
   }
 
   @Override

--- a/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
+++ b/dc-commons-file/src/main/java/de/digitalcollections/commons/file/backend/impl/IdentifierPatternToFileResourceUriResolverImpl.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.commons.file.backend.impl;
 
-
 import de.digitalcollections.commons.file.backend.api.IdentifierToFileResourceUriResolver;
 import de.digitalcollections.model.exception.ResourceIOException;
 import de.digitalcollections.model.file.MimeType;


### PR DESCRIPTION
Hi,

this PR adjusts the `getUris` method and checks the correct return type (`MIME_APPLICATION_OCTET_STREAM` instead of `null`), because this is necessary due to changes introduced in `dc-model`:

https://github.com/dbmdz/digitalcollections-model/commit/331ba13afdadd3da03fc99ac03190eb88d7e84d0