### PR TITLE
changelog: add entry for latest 6.0.1 release

### DIFF
--- a/dc-commons-file/CHANGELOG.md
+++ b/dc-commons-file/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+## [6.0.1](https://github.com/dbmdz/digitalcollections-commons/releases/tag/dc-commons-file-6.0.1) - 2023-03-08
+
+### Changed
+
+- Fix MIME-type check of `getUris()` method due to changes in `dc-model` (#871)
+
 ## [6.0.0](https://github.com/dbmdz/digitalcollections-commons/releases/tag/dc-commons-file-6.0.0) - 2022-07-18
 
 ### Changed


### PR DESCRIPTION
Hi,

this PR extends changelog of dc-commons-file and mentions latest 6.0.1 release.